### PR TITLE
Generalize type signature of KV.of

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/values/KV.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/values/KV.java
@@ -35,8 +35,8 @@ public class KV<K, V> implements Serializable {
   private static final long serialVersionUID = 0;
 
   /** Returns a KV with the given key and value. */
-  public static <K, V> KV<K, V> of(K key, V value) {
-    return new KV<>(key, value);
+  public static <K, SK extends K, V, SV extends V> KV<K, V> of(SK key, SV value) {
+    return new KV<K, V>(key, value);
   }
 
   /** Returns the key of this KV. */


### PR DESCRIPTION
I found myself having to write this:
KV&lt;String, Iterable&lt;String&gt;&gt; kv = KV.&lt;String, Iterable&lt;String&gt;&gt;of("foo", new ArrayList&lt;String&gt;());

When I would have preferred to write this:
KV&lt;String, Iterable&lt;String&gt;&gt; kv = KV.of("foo", new ArrayList&lt;String&gt;());

What do you think about this change?