### PR TITLE
Make fn in Combine.PerKey Non-Transient, Add Getter

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/Combine.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/Combine.java
@@ -910,6 +910,13 @@ public class Combine {
       this.fn = fn;
     }
 
+    /**
+     * Returns the KeyedCombineFn used by this Combine operation.
+     */
+    public KeyedCombineFn<? super K, ? super VI, ?, VO> getFn() {
+      return fn;
+    }
+
     @Override
     public PCollection<KV<K, VO>> apply(PCollection<KV<K, VI>> input) {
       return input


### PR DESCRIPTION
We are implementing a PipelineRunner for Apache Flink: http://flink.apache.org. Making the KeyedCombineFn accessible in Combine.PerKey would allow us to translate it to a more efficient runtime operation.