### PR TITLE
increase scope of a few classes to write APIs against them

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/CoGbkResultSchema.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/CoGbkResultSchema.java
@@ -38,7 +38,7 @@ import java.util.List;
  * CoGroupByKey).
  */
 @SuppressWarnings("serial")
-class CoGbkResultSchema implements Serializable {
+public class CoGbkResultSchema implements Serializable {
 
   private final TupleTagList tupleTagList;
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/KeyedPCollectionTuple.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/KeyedPCollectionTuple.java
@@ -151,7 +151,8 @@ public class KeyedPCollectionTuple<K> implements PInput {
    * A utility class to help ensure coherence of tag and input PCollection
    * types.
    */
-  static class TaggedKeyedPCollection<K, V> {
+  public static class TaggedKeyedPCollection<K, V> {
+
     final TupleTag<V> tupleTag;
     final PCollection<KV<K, V>> pCollection;
 
@@ -160,6 +161,20 @@ public class KeyedPCollectionTuple<K> implements PInput {
         PCollection<KV<K, V>> pCollection) {
       this.tupleTag = tupleTag;
       this.pCollection = pCollection;
+    }
+
+    /**
+     * Returns the underlying PCollection of this TaggedKeyedPCollection.
+     */
+    public PCollection<KV<K, V>> getCollection() {
+      return pCollection;
+    }
+
+    /**
+     * Returns the TupleTag of this TaggedKeyedPCollection.
+     */
+    public TupleTag<V> getTupleTag() {
+      return tupleTag;
     }
   }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/RawUnionValue.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/RawUnionValue.java
@@ -23,7 +23,7 @@ package com.google.cloud.dataflow.sdk.transforms.join;
  * This corresponds to an integer union tag and value.  The mapping of
  * union tag to type must come from elsewhere.
  */
-class RawUnionValue {
+public class RawUnionValue {
   private final int unionTag;
   private final Object value;
 


### PR DESCRIPTION
This pull request is similar to #8 in the sense that it exposes some internal API classes and fields. The intention is to write a custom `coGroupByKey` translator. For that, we need access to `CoGbkResultSchema`, `TaggedKeyedPCollection`, and `RawUnionValue`.