### PR TITLE
Modify checkstyle to accept new copyright header.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (C) 2015 Google Inc.
+  ~ Copyright (C) 2015 The Google Cloud Dataflow Authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,13 @@ page at http://checkstyle.sourceforge.net/config.html -->
       notice, so that this required text appears on the second line:
       <pre>
         /*
+         * Copyright 2015 The Google Cloud Dataflow Authors
+         *
+         * (details of open-source license...)
+      </pre>
+      or
+      <pre>
+        /*
          * Copyright 2015 Google Inc.
          *
          * (details of open-source license...)
@@ -39,7 +46,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
         value="^(//| \*) Copyright (\([cC]\) )?[\d]{4}(\-[\d]{4})? (Google Inc\.|The Google Cloud Dataflow Authors).*$" />
     <property name="minimum" value="1" />
     <property name="maximum" value="10" />
-    <property name="message" value="Google copyright is missing or malformed." />
+    <property name="message" value="Copyright is missing or malformed." />
     <property name="severity" value="error" />
   </module>
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,7 +36,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
       </pre>
     -->
     <property name="format"
-        value="^(//| \*) Copyright (\([cC]\) )?[\d]{4}(\-[\d]{4})? (Google Inc\.).*$" />
+        value="^(//| \*) Copyright (\([cC]\) )?[\d]{4}(\-[\d]{4})? (Google Inc\.|The Google Cloud Dataflow Authors).*$" />
     <property name="minimum" value="1" />
     <property name="maximum" value="10" />
     <property name="message" value="Google copyright is missing or malformed." />


### PR DESCRIPTION
As discussed in https://github.com/GoogleCloudPlatform/DataflowJavaSDK/pull/10
With external contributors the copyright header should be:
Copyright (C) 2015 The Google Cloud Dataflow Authors

Old copyright header is still accepted.