### PR TITLE
Fix a typo of method name in WindowingWordCount.Options.

### DIFF
--- a/examples/src/main/java/com/google/cloud/dataflow/examples/WindowingWordCount.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/WindowingWordCount.java
@@ -41,18 +41,19 @@ import org.joda.time.Instant;
  * example see:
  *   https://cloud.google.com/dataflow/java-sdk/wordcount-example
  *
- * To execute this pipeline locally, specify general pipeline configuration:
+ * <p> To execute this pipeline locally, specify general pipeline configuration:
  *   --project=<PROJECT ID>
- * and example configuration:
- *   --output=[<LOCAL FILE> | gs://<OUTPUT PATH>]
+ * and a local output file or output prefix on GCS:
+ *   --output=[<LOCAL FILE> | gs://<OUTPUT PREFIX>]
  *
- * To execute this pipeline using the Dataflow service, specify pipeline configuration:
- *   --project=<PROJECT ID> --stagingLocation=gs://<STAGING DIRECTORY>
+ * <p> To execute this pipeline using the Dataflow service, specify pipeline configuration:
+ *   --project=<PROJECT ID>
+ *   --stagingLocation=gs://<STAGING DIRECTORY>
  *   --runner=BlockingDataflowPipelineRunner
- * and example configuration:
- *   --output=gs://<OUTPUT PATH>
+ * and an output prefix on GCS:
+ *   --output=gs://<OUTPUT PREFIX>
  *
- * The input file defaults to gs://dataflow-samples/shakespeare/kinglear.txt and can be
+ * <p> The input file defaults to gs://dataflow-samples/shakespeare/kinglear.txt and can be
  * overridden with --input.
  */
 public class WindowingWordCount {

--- a/examples/src/main/java/com/google/cloud/dataflow/examples/WindowingWordCount.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/WindowingWordCount.java
@@ -136,7 +136,7 @@ public class WindowingWordCount {
     @Description("Number of output shards (0 if the system should choose automatically)")
     @Default.Integer(0)
     int getNumShards();
-    void setNumShard(int value);
+    void setNumShards(int value);
   }
 
   private static String getOutputLocation(Options options) {


### PR DESCRIPTION
When I've practiced with DataflowJavaSDK examples based on the documentation (https://cloud.google.com/dataflow/java-sdk/wordcount-example), I encountered the ERROR shown below with WindowingWordCount.

```
$ mvn exec:java -pl examples -Dexec.mainClass=com.google.cloud.dataflow.examples.WindowingWordCount -Dexec.args="--project=${PROJECT} --stagingLocation=${STAGING} --runner=BlockingDataflowPipelineRunner --output=${OUTPUT}"
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Google Cloud Dataflow Java Examples - All manual_build
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] >>> exec-maven-plugin:1.1:java (default-cli) > validate @ google-cloud-dataflow-java-examples-all >>>
[INFO]
[INFO] <<< exec-maven-plugin:1.1:java (default-cli) < validate @ google-cloud-dataflow-java-examples-all <<<
[INFO]
[INFO] --- exec-maven-plugin:1.1:java (default-cli) @ google-cloud-dataflow-java-examples-all ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.056 s
[INFO] Finished at: 2015-03-16T16:28:08+09:00
[INFO] Final Memory: 16M/441M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.1:java (default-cli) on project google-cloud-dataflow-java-examples-all: An exception occured while executing the Java class. null: InvocationTargetException: Expected getter for property [numShard] of type [int] on [com.google.cloud.dataflow.examples.WindowingWordCount$Options]. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

It seems caused by a typo in WindowingWordCount.Options method name. This pull request seems ease this problem on my environment.
Sorry for the noise in javadoc changes. It just aims to synchronize with WordCount.java.  I'm ready to split them if needed.
When I practice with DataflowJavaSDK examples based on the documentation (https://cloud.google.com/dataflow/java-sdk/wordcount-example), I have encountered the ERROR shown below with WindowingWordCount.

```
$ mvn exec:java -pl examples -Dexec.mainClass=com.google.cloud.dataflow.examples.WindowingWordCount -Dexec.args="--project=${PROJECT} --stagingLocation=${STAGING} --runner=BlockingDataflowPipelineRunner --output=${OUTPUT}"
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Google Cloud Dataflow Java Examples - All manual_build
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] >>> exec-maven-plugin:1.1:java (default-cli) > validate @ google-cloud-dataflow-java-examples-all >>>
[INFO]
[INFO] <<< exec-maven-plugin:1.1:java (default-cli) < validate @ google-cloud-dataflow-java-examples-all <<<
[INFO]
[INFO] --- exec-maven-plugin:1.1:java (default-cli) @ google-cloud-dataflow-java-examples-all ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.056 s
[INFO] Finished at: 2015-03-16T16:28:08+09:00
[INFO] Final Memory: 16M/441M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.1:java (default-cli) on project google-cloud-dataflow-java-examples-all: An exception occured while executing the Java class. null: InvocationTargetException: Expected getter for property [numShard] of type [int] on [com.google.cloud.dataflow.examples.WindowingWordCount$Options]. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

It seems caused by a typo in WindowingWordCount.Options method name. This pull request seems ease this problem on my environment.
Sorry for the noise in javadoc changes. It just aims to synchronize with WordCount.java.  I'm ready to split them if needed.