### PR TITLE
Getters for unexposed WindowFn fields

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/CalendarWindows.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/CalendarWindows.java
@@ -142,6 +142,19 @@ public class CalendarWindows {
           && startDate == that.startDate
           && timeZone == that.timeZone;
     }
+
+    public int getNumber() {
+      return number;
+    }
+
+    public DateTime getStartDate() {
+      return startDate;
+    }
+
+    public DateTimeZone getTimeZone() {
+      return timeZone;
+    }
+
   }
 
   /**
@@ -218,6 +231,23 @@ public class CalendarWindows {
           && startDate == that.startDate
           && timeZone == that.timeZone;
     }
+
+    public int getNumber() {
+      return number;
+    }
+
+    public int getDayOfMonth() {
+      return dayOfMonth;
+    }
+
+    public DateTime getStartDate() {
+      return startDate;
+    }
+
+    public DateTimeZone getTimeZone() {
+      return timeZone;
+    }
+
   }
 
   /**
@@ -299,5 +329,26 @@ public class CalendarWindows {
           && startDate == that.startDate
           && timeZone == that.timeZone;
     }
+
+    public DateTimeZone getTimeZone() {
+      return timeZone;
+    }
+
+    public DateTime getStartDate() {
+      return startDate;
+    }
+
+    public int getDayOfMonth() {
+      return dayOfMonth;
+    }
+
+    public int getMonthOfYear() {
+      return monthOfYear;
+    }
+
+    public int getNumber() {
+      return number;
+    }
+
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/FixedWindows.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/FixedWindows.java
@@ -91,4 +91,13 @@ public class FixedWindows extends PartitioningWindowFn<Object, IntervalWindow> {
         && (size.equals(((FixedWindows) other).size))
         && (offset.equals(((FixedWindows) other).offset));
   }
+
+  public Duration getSize() {
+    return size;
+  }
+
+  public Duration getOffset() {
+    return offset;
+  }
+
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/Sessions.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/Sessions.java
@@ -79,4 +79,9 @@ public class Sessions extends WindowFn<Object, IntervalWindow> {
   public boolean isCompatible(WindowFn<?, ?> other) {
     return other instanceof Sessions;
   }
+
+  public Duration getGapDuration() {
+    return gapDuration;
+  }
+
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/SlidingWindows.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/SlidingWindows.java
@@ -143,4 +143,17 @@ public class SlidingWindows extends NonMergingWindowFn<Object, IntervalWindow> {
     }
     return Duration.millis(1);
   }
+
+  public Duration getPeriod() {
+    return period;
+  }
+
+  public Duration getSize() {
+    return size;
+  }
+
+  public Duration getOffset() {
+    return offset;
+  }
+
 }


### PR DESCRIPTION
This change exposes fields of `WindowFn` subclasses. Needed for properly translating window functionality onto other backends - Apache Flink in my specific case.

The proposed change was discussed in #18.