### PR TITLE
Proof of concept of a typed BigQuery reader

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/dataflow/BigQueryIOTranslator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/dataflow/BigQueryIOTranslator.java
@@ -40,11 +40,11 @@ public class BigQueryIOTranslator {
   /**
    * Implements BigQueryIO Read translation for the Dataflow backend.
    */
-  public static class ReadTranslator
-      implements DataflowPipelineTranslator.TransformTranslator<BigQueryIO.Read.Bound> {
+  public static class ReadTranslator<T>
+      implements DataflowPipelineTranslator.TransformTranslator<BigQueryIO.Read.Bound<T>> {
 
     @Override
-    public void translate(BigQueryIO.Read.Bound transform,
+    public void translate(BigQueryIO.Read.Bound<T> transform,
                           DataflowPipelineTranslator.TranslationContext context) {
       TableReference table = transform.getTable();
       if (table.getProjectId() == null) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/worker/BigQueryReader.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/worker/BigQueryReader.java
@@ -20,7 +20,9 @@ import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.cloud.dataflow.sdk.options.BigQueryOptions;
+import com.google.cloud.dataflow.sdk.util.AbstractBigQueryIterator;
 import com.google.cloud.dataflow.sdk.util.BigQueryTableRowIterator;
+import com.google.cloud.dataflow.sdk.util.BigQueryTypedIterator;
 import com.google.cloud.dataflow.sdk.util.Transport;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.cloud.dataflow.sdk.util.common.worker.Reader;
@@ -35,44 +37,56 @@ import java.util.NoSuchElementException;
  * query for all rows of a table and then iterates over the result. There is no support for
  * progress reporting because the source is used only in situations where the entire table must be
  * read by each worker (i.e. the source is used as a side input).
+ *
+ * @param <T> the type of the elements read from the source
  */
-public class BigQueryReader extends Reader<WindowedValue<TableRow>> {
+public class BigQueryReader<T> extends Reader<WindowedValue<T>> {
   final TableReference tableRef;
   final BigQueryOptions bigQueryOptions;
   final Bigquery bigQueryClient;
+  final Class<T> type;
 
   /** Builds a BigQuery source using pipeline options to instantiate a Bigquery client. */
-  public BigQueryReader(BigQueryOptions bigQueryOptions, TableReference tableRef) {
+  public BigQueryReader(BigQueryOptions bigQueryOptions, TableReference tableRef, Class<T> type) {
     // Save pipeline options so that we can construct the BigQuery client on-demand whenever an
     // iterator gets created.
     this.bigQueryOptions = bigQueryOptions;
     this.tableRef = tableRef;
     this.bigQueryClient = null;
+    this.type = type;
   }
 
   /** Builds a BigQueryReader directly using a BigQuery client. */
-  public BigQueryReader(Bigquery bigQueryClient, TableReference tableRef) {
+  public BigQueryReader(Bigquery bigQueryClient, TableReference tableRef, Class<T> type) {
     this.bigQueryOptions = null;
     this.tableRef = tableRef;
     this.bigQueryClient = bigQueryClient;
+    this.type = type;
   }
 
   @Override
-  public ReaderIterator<WindowedValue<TableRow>> iterator() throws IOException {
+  public ReaderIterator<WindowedValue<T>> iterator() throws IOException {
     return new BigQueryReaderIterator(
         bigQueryClient != null
             ? bigQueryClient : Transport.newBigQueryClient(bigQueryOptions).build(),
-        tableRef);
+        tableRef,
+        type);
   }
 
   /**
    * A ReaderIterator that yields TableRow objects for each row of a BigQuery table.
    */
-  class BigQueryReaderIterator extends AbstractReaderIterator<WindowedValue<TableRow>> {
-    private BigQueryTableRowIterator rowIterator;
+  class BigQueryReaderIterator extends AbstractReaderIterator<WindowedValue<T>> {
+    private AbstractBigQueryIterator<T> rowIterator;
 
-    public BigQueryReaderIterator(Bigquery bigQueryClient, TableReference tableRef) {
-      rowIterator = new BigQueryTableRowIterator(bigQueryClient, tableRef);
+    public BigQueryReaderIterator(Bigquery bigQueryClient, TableReference tableRef, Class<T> type) {
+      if (type == TableRow.class) {
+        rowIterator = (AbstractBigQueryIterator<T>) new BigQueryTableRowIterator(
+          bigQueryClient,
+          tableRef);
+      } else {
+        rowIterator = new BigQueryTypedIterator(bigQueryClient, tableRef, type);
+      }
     }
 
     @Override
@@ -81,7 +95,7 @@ public class BigQueryReader extends Reader<WindowedValue<TableRow>> {
     }
 
     @Override
-    public WindowedValue<TableRow> next() throws IOException {
+    public WindowedValue<T> next() throws IOException {
       if (!hasNext()) {
         throw new NoSuchElementException();
       }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/AbstractBigQueryIterator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/AbstractBigQueryIterator.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.util;
+
+import com.google.api.client.util.BackOff;
+import com.google.api.client.util.BackOffUtils;
+import com.google.api.client.util.Sleeper;
+import com.google.api.services.bigquery.Bigquery;
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableDataList;
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterates over all rows in a table.
+ *
+ * @param <T> the type of the elements read from the source
+ */
+public abstract class AbstractBigQueryIterator<T> implements Iterator<T>, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(BigQueryTableRowIterator.class);
+
+  private final Bigquery client;
+  private final TableReference ref;
+  protected TableSchema schema;
+  private String pageToken;
+  private Iterator<TableRow> rowIterator;
+  // Set true when the final page is seen from the service.
+  private boolean lastPage = false;
+
+  // The maximum number of times a BigQuery request will be retried
+  private static final int MAX_RETRIES = 3;
+  // Initial wait time for the backoff implementation
+  private static final int INITIAL_BACKOFF_MILLIS = 1000;
+
+
+  public AbstractBigQueryIterator(Bigquery client, TableReference ref) {
+    this.client = client;
+    this.ref = ref;
+  }
+
+  @Override
+  public boolean hasNext() {
+    try {
+      if (!isOpen()) {
+        open();
+      }
+
+      if (!rowIterator.hasNext() && !lastPage) {
+        readNext();
+      }
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    return rowIterator.hasNext();
+  }
+
+  protected abstract T getTypedTableRow(List<TableFieldSchema> fields, Map<String, Object> rawRow);
+
+  protected abstract void buildMapper();
+
+  @Override
+  public T next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    // Embed schema information into the raw row, so that values have an
+    // associated key.  This matches how rows are read when using the
+    // DataflowPipelineRunner.
+    return getTypedTableRow(schema.getFields(), rowIterator.next());
+  }
+
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  private void readNext() throws IOException, InterruptedException {
+    Bigquery.Tabledata.List list = client.tabledata()
+      .list(ref.getProjectId(), ref.getDatasetId(), ref.getTableId());
+    if (pageToken != null) {
+      list.setPageToken(pageToken);
+    }
+
+    Sleeper sleeper = Sleeper.DEFAULT;
+    BackOff backOff = new AttemptBoundedExponentialBackOff(MAX_RETRIES, INITIAL_BACKOFF_MILLIS);
+
+    TableDataList result = null;
+    while (true) {
+      try {
+        result = list.execute();
+        break;
+      } catch (IOException e) {
+        LOG.error("Error reading from BigQuery table {} of dataset {} : {}", ref.getTableId(),
+          ref.getDatasetId(), e.getMessage());
+        if (!BackOffUtils.next(sleeper, backOff)) {
+          LOG.error("Aborting after {} retries.", MAX_RETRIES);
+          throw e;
+        }
+      }
+    }
+
+    pageToken = result.getPageToken();
+    rowIterator = result.getRows() != null ? result.getRows().iterator() :
+      Collections.<TableRow>emptyIterator();
+
+    // The server may return a page token indefinitely on a zero-length table.
+    if (pageToken == null ||
+      result.getTotalRows() != null && result.getTotalRows() == 0) {
+      lastPage = true;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    // Prevent any further requests.
+    lastPage = true;
+  }
+
+  private boolean isOpen() {
+    return schema != null;
+  }
+
+  /**
+   * Opens the table for read.
+   * @throws IOException on failure
+   */
+  private void open() throws IOException, InterruptedException {
+    // Get table schema.
+    Bigquery.Tables.Get get = client.tables()
+      .get(ref.getProjectId(), ref.getDatasetId(), ref.getTableId());
+
+    Sleeper sleeper = Sleeper.DEFAULT;
+    BackOff backOff = new AttemptBoundedExponentialBackOff(MAX_RETRIES, INITIAL_BACKOFF_MILLIS);
+    Table table = null;
+
+    while (true) {
+      try {
+        table = get.execute();
+        break;
+      } catch (IOException e) {
+        LOG.error("Error opening BigQuery table {} of dataset {} : {}", ref.getTableId(),
+          ref.getDatasetId(), e.getMessage());
+        if (!BackOffUtils.next(sleeper, backOff)) {
+          LOG.error("Aborting after {} retries.", MAX_RETRIES);
+          throw e;
+        }
+      }
+    }
+
+    schema = table.getSchema();
+    buildMapper();
+
+    // Read the first page of results.
+    readNext();
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqColumn.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqColumn.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.util.bqmap;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface BqColumn {
+
+   String name();
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqField.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqField.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.util.bqmap;
+
+/**
+ *
+ */
+public abstract class BqField {
+   public abstract void set(Object o, Object v);
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqFieldDebug.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqFieldDebug.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.util.bqmap;
+
+import java.lang.reflect.Field;
+
+/**
+ *
+ */
+class BqFieldDebug extends BqField {
+
+  private Field field;
+
+  public BqFieldDebug(Field field) {
+    this.field = field;
+  }
+
+  public void set(Object o, Object v) {
+    String value = (String) v;
+    Class<?> type = field.getType();
+    if (type == Integer.class) {
+      try {
+        field.set(o, Integer.valueOf(value));
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      }
+    } else if (type == String.class) {
+      try {
+        field.set(o, value);
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      }
+    } else if (type == Double.class) {
+      try {
+        field.set(o, Double.valueOf(value));
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      }
+    } else if (type == Float.class) {
+      try {
+        field.set(o, Float.valueOf(value));
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      }
+    }
+
+    System.out.println();
+
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqFieldNoop.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqFieldNoop.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.util.bqmap;
+
+/**
+ *
+ */
+class BqFieldNoop extends BqField {
+  public void set(Object o, Object v) {
+
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqTypeMapper.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/bqmap/BqTypeMapper.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.util.bqmap;
+
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableSchema;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class BqTypeMapper {
+
+  private Map<String, BqField> map = new HashMap<>();
+
+
+  //    if (Data.isNull(v)) {
+//      return null;
+//    }
+//
+//    if (Objects.equals(fieldSchema.getMode(), "REPEATED")) {
+//      TableFieldSchema elementSchema = fieldSchema.clone().setMode("REQUIRED");
+//      @SuppressWarnings("unchecked")
+//      List<Map<String, Object>> rawValues = (List<Map<String, Object>>) v;
+//      List<Object> values = new ArrayList<Object>(rawValues.size());
+//      for (Map<String, Object> element : rawValues) {
+//        values.add(getTypedCellValue(elementSchema, element.get("v")));
+//      }
+//      return values;
+//    }
+//
+//    if (fieldSchema.getType().equals("RECORD")) {
+//      @SuppressWarnings("unchecked")
+//      Map<String, Object> typedV = (Map<String, Object>) v;
+//      return getTypedTableRow(fieldSchema.getFields(), typedV);
+//    }
+//
+//    if (fieldSchema.getType().equals("FLOAT")) {
+//      return Double.parseDouble((String) v);
+//    }
+//
+//    if (fieldSchema.getType().equals("BOOLEAN")) {
+//      return Boolean.parseBoolean((String) v);
+//    }
+//
+//    if (fieldSchema.getType().equals("TIMESTAMP")) {
+//      // Seconds to milliseconds
+//      long milliSecs = (new Double(Double.parseDouble((String) v) * 1000)).longValue();
+//      DateTimeFormatter formatter =
+//          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS").withZoneUTC();
+//      return formatter.print(milliSecs) + " UTC";
+//    }
+//
+//    return v;
+  public <T> BqTypeMapper(Class<T> type, TableSchema schema) {
+    Field[] typeFields = type.getFields();
+
+
+    List<TableFieldSchema> fields = schema.getFields();
+    for (TableFieldSchema field : fields) {
+      String name = field.getName();
+      // First pass looking for annotations
+      for (Field typeField : typeFields) {
+        BqColumn annotation = typeField.getAnnotation(BqColumn.class);
+        if (annotation != null) {
+          if (name.equals(annotation.name())) {
+            Class<?> t = typeField.getType();
+
+            System.out.println(t.toString());
+            map.put(name, new BqFieldDebug(typeField));
+            continue;
+            //map.put(name,)
+          }
+        }
+      }
+      // Second pass looking field names
+      try {
+        Field typeField = type.getField(name);
+        map.put(name, new BqFieldDebug(typeField));
+        continue;
+      } catch (NoSuchFieldException e) {
+      }
+      // default
+      if (map.get(name) == null) {
+        map.put(name, new BqFieldNoop());
+      }
+    }
+  }
+
+  public void set(String name, Object o, Object v) {
+    BqField bqFieldMap = map.get(name);
+    bqFieldMap.set(o, v);
+  }
+
+
+}


### PR DESCRIPTION
The is not a Pull Request for merge, but a Request For Comment on a feature I'm developing. I like to know if this is a feature that would be considered to be merged in. It needs some more development but if I know it won't be accepted anyway I will abandon this feature as a "core" merge.

What is the feature: An object mapper for BigQuery. My experience with Dataflow tells me to stop using loosely typed object as soon as possible, so it's best to go types at the border: The reader. So having a build in mapper helps data flow users. (this will come in handy more for ETL type of flows). Example usage: 

``` java
    PCollection<Match> pcMatch = pipeline
      .apply(BigQueryIO.Read
        .withType(Match.class)
        .named("Foo")
        .from("test.match"))
```

Note: This is a _Proof Of Concept_ and need development. What needs development:
- Only support Integer, Float and String. Need more types
- Maybe use the Jackson Object mapper
- Can't figure out to Coder working on the Dataflow service. Could use some pointers
- Need more tests
