### PR TITLE
Fix documentation of PubsubIO subscription format

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/PubsubIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/PubsubIO.java
@@ -302,7 +302,7 @@ public class PubsubIO {
      * a specific Pubsub subscription. Mutually exclusive with
      * PubsubIO.Read.topic().
      * Cloud Pubsub subscription names should be of the form
-     * {@code /subscriptions/<project>/<<subscription>},
+     * {@code projects/<project>/subscriptions/<subscription>},
      * where {@code <project>} is the name of the project the subscription belongs to.
      * The {@code <subscription>} component must comply with the below requirements.
      *


### PR DESCRIPTION
The Java doc for the format of a subscription string is incorrect.