### PR TITLE
Fixed close not being called

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BoundedReadFromUnboundedSource.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BoundedReadFromUnboundedSource.java
@@ -258,7 +258,9 @@ class BoundedReadFromUnboundedSource<T> extends PTransform<PInput, PCollection<T
       }
 
       @Override
-      public void close() {}
+      public void close() throws IOException {
+        reader.close();
+      }
 
       @Override
       public BoundedSource<ValueWithRecordId<T>> getCurrentSource() {


### PR DESCRIPTION
`close()` is not called by wrapping `BoundedReadFromUnboundedSource` resulting in finalization behavior for the `UnboundedSource` not executing. 