### PR TITLE
Fixed typo in doc

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -155,7 +155,7 @@ import java.util.regex.Pattern;
  * here's code that outputs daily tables to BigQuery:
  * <pre>{@code
  * PCollection<TableRow> quotes = ...
- * quotes.apply(Window.<TableRow>info(CalendarWindows.days(1)))
+ * quotes.apply(Window.<TableRow>into(CalendarWindows.days(1)))
  *       .apply(BigQueryIO.Write
  *         .named("Write")
  *         .withSchema(schema)

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -161,8 +161,8 @@ import java.util.regex.Pattern;
  *         .withSchema(schema)
  *         .to(new SerializableFunction<BoundedWindow, String>() {
  *               public String apply(BoundedWindow window) {
- *                 String dayString = DateTimeFormat.forPattern("yyyy_MM_dd").parseDateTime(
- *                   ((DaysWindow) window).getStartDate());
+ *                 String dayString = DateTimeFormat.forPattern("yyyyMMdd").print(
+ *                   ((IntervalWindow) window).start());
  *                 return "my-project:output.output_table_" + dayString;
  *               }
  *             }));


### PR DESCRIPTION
Fixed typo in the doc. 
Window has ```into``` [method](https://cloud.google.com/dataflow/java-sdk/JavaDoc/com/google/cloud/dataflow/sdk/transforms/windowing/Window#into-com.google.cloud.dataflow.sdk.transforms.windowing.WindowFn-) but not ```info```