### PR TITLE
Travis: cache the Maven directory of downloaded jars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: java
 
 sudo: false
 
+before_cache:
+  - find $HOME/.m2 -name '*manual_build*' -o -name '*SNAPSHOT*' | xargs rm -rf
+
+cache:
+  directories:
+    - $HOME/.m2
+
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,8 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
 
 install:
-  - travis_retry mvn install clean -U -DskipTests=true
+  - mvn versions:set -DnewVersion=manual_build
+  - travis_retry mvn install -U
 
 script:
-  - travis_retry mvn versions:set -DnewVersion=manual_build
-  - travis_retry mvn install -U
   - travis_retry travis/test_wordcount.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+sudo: false
+
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Reduce failure rate of downloading from Maven

The first run should be slower, but subsequent runs should
be faster.