### PR TITLE
Fixup PR #47

### DIFF
--- a/contrib/hadoop/AUTHORS.md
+++ b/contrib/hadoop/AUTHORS.md
@@ -1,6 +1,7 @@
-# Authors of hadoop
+# Authors of 'hadoop' module
 
 The following is the official list of authors for copyright purposes of this community-contributed module.
 
     Cloudera
     Tom White, tom [at] cloudera [dot] com
+    Google Inc.

--- a/contrib/hadoop/README.md
+++ b/contrib/hadoop/README.md
@@ -1,8 +1,8 @@
-Hadoop
-======
+Hadoop module
+=============
 
 This library provides Dataflow sources and sinks to make it possible to read and write
-Apache Hadoop file formats from Dataflow programs.
+Apache Hadoop file formats from Dataflow pipelines.
 
 Currently, only the read path is implemented. A `HadoopFileSource` allows any Hadoop
 `FileInputFormat` to be read as a `PCollection`.
@@ -10,12 +10,16 @@ Currently, only the read path is implemented. A `HadoopFileSource` allows any Ha
 A `HadoopFileSource` can be read from using the `com.google.cloud.dataflow.sdk.io.Read`
 transform. For example:
 
-    HadoopFileSource<K, V> source = HadoopFileSource.from(path, MyInputFormat.class,
-      MyKey.class, MyValue.class);
-    PCollection<KV<MyKey, MyValue>> records = Read.from(mySource);
+```java
+HadoopFileSource<K, V> source = HadoopFileSource.from(path, MyInputFormat.class,
+  MyKey.class, MyValue.class);
+PCollection<KV<MyKey, MyValue>> records = Read.from(mySource);
+```
 
 Alternatively, the `readFrom` method is a convenience method that returns a read
 transform. For example:
 
-    PCollection<KV<MyKey, MyValue>> records = HadoopFileSource.readFrom(path,
-      MyInputFormat.class, MyKey.class, MyValue.class);
+```java
+PCollection<KV<MyKey, MyValue>> records = HadoopFileSource.readFrom(path,
+  MyInputFormat.class, MyKey.class, MyValue.class);
+```

--- a/contrib/hadoop/pom.xml
+++ b/contrib/hadoop/pom.xml
@@ -36,7 +36,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <google-cloud-dataflow-version>manual_build</google-cloud-dataflow-version>
+    <google-cloud-dataflow-version>[1.2.0,2.0.0)</google-cloud-dataflow-version>
   </properties>
 
   <build>
@@ -114,11 +114,11 @@
           <offlineLinks>
             <offlineLink>
               <url>https://cloud.google.com/dataflow/java-sdk/JavaDoc/</url>
-              <location>${basedir}/../javadoc/dataflow-sdk-docs</location>
+              <location>${basedir}/../../javadoc/dataflow-sdk-docs</location>
             </offlineLink>
             <offlineLink>
               <url>http://docs.guava-libraries.googlecode.com/git-history/release18/javadoc/</url>
-              <location>${basedir}/../javadoc/guava-docs</location>
+              <location>${basedir}/../../javadoc/guava-docs</location>
             </offlineLink>
           </offlineLinks>
         </configuration>
@@ -141,6 +141,9 @@
       <version>${google-cloud-dataflow-version}</version>
     </dependency>
 
+	<!-- @tomwhite: Hadoop doesn't have great RPC client compatibility between one version and
+	another so it's common to mark the Hadoop dependency as provided and have users specify the
+	version they need in their project. -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
@@ -149,7 +152,6 @@
     </dependency>
 
     <!-- test dependencies -->
-
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
@@ -161,14 +163,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud.dataflow</groupId>
-      <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-      <version>${google-cloud-dataflow-version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/contrib/hadoop/src/test/java/com/google/cloud/dataflow/contrib/hadoop/HadoopFileSourceTest.java
+++ b/contrib/hadoop/src/test/java/com/google/cloud/dataflow/contrib/hadoop/HadoopFileSourceTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.dataflow.contrib.hadoop;
 
-import static com.google.cloud.dataflow.sdk.io.SourceTestUtils.readFromSource;
+import static com.google.cloud.dataflow.sdk.testing.SourceTestUtils.readFromSource;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -25,10 +25,11 @@ import static org.junit.Assert.fail;
 
 import com.google.cloud.dataflow.sdk.io.BoundedSource;
 import com.google.cloud.dataflow.sdk.io.Source;
-import com.google.cloud.dataflow.sdk.io.SourceTestUtils;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.testing.SourceTestUtils;
 import com.google.cloud.dataflow.sdk.values.KV;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
@@ -39,6 +40,7 @@ import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/contrib/hadoop/src/test/java/com/google/cloud/dataflow/contrib/hadoop/WritableCoderTest.java
+++ b/contrib/hadoop/src/test/java/com/google/cloud/dataflow/contrib/hadoop/WritableCoderTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.dataflow.contrib.hadoop;
 
 import com.google.cloud.dataflow.sdk.testing.CoderProperties;
+
 import org.apache.hadoop.io.IntWritable;
 import org.junit.Test;
 


### PR DESCRIPTION
hadoop contrib: make it compile against latest
    
- Update version to recommended [1.0.0,2.0.0)
- SourceTestUtils moved packages
- Removed test-jar from pom.xml
- Fixup path to javadoc folders
- Java syntax highlighting in README.md
    
Now, `mvn verify` passes when run in the `contrib/hadoop` folder.