### PR TITLE
worker: fix leak in StateSampler

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/common/worker/StateSampler.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/common/worker/StateSampler.java
@@ -210,7 +210,7 @@ public class StateSampler implements AutoCloseable {
         Counter<Long> counter = counterSetMutator.addCounter(
             Counter.longs(counterName, Counter.AggregationKind.SUM));
         state = countersByState.size();
-        statesByName.put(name, state);
+        statesByName.put(counterName, state);
         countersByState.add(counter);
         kindsByState.put(state, kind);
       }


### PR DESCRIPTION
Mismatching keys were being used for get and set in the statesByName map, causing the state/counter existence check to always fail and every invocation of stateForName() to create a new counter and state.

This manifests as a memory leak where the majority of the heap is consumed by the contents of statesByName and kindsByState, ultimately causing the worker to fail.