### PR TITLE
Change BQ mode to append instead of truncate

### DIFF
--- a/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
@@ -251,7 +251,7 @@ public class WindowedWordCount {
           .to(getTableReference(options))
           .withSchema(getSchema())
           .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
-          .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE));
+          .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND));
 
     PipelineResult result = pipeline.run();
 


### PR DESCRIPTION
It appears that truncate mode is not supported for unbounded
PCollection.

Error message:

[ERROR] Failed to execute goal
org.codehaus.mojo:exec-maven-plugin:1.1:java (default-cli) on
project
google-cloud-dataflow-java-examples-all: An exception occured while
executing th
e Java class. null: InvocationTargetException:
WriteDisposition.WRITE_TRUNCATE is not supported for unbounded
PCollections or when using tablespec functions. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with
the
-e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug
logging.
[ERROR]
[ERROR] For more information about the errors and possible
solutions,
please read the following articles:
[ERROR] [Help 1]
http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException