### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 
-sudo: false
+# Disable container build because of unresolved Travis+JVM issues
+#   See: https://github.com/travis-ci/travis-ci/issues/3396
+# sudo: false
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ env:
     - CUSTOM_JDK="default"
     - CUSTOM_JDK="oraclejdk8"
     - CUSTOM_JDK="oraclejdk7"
-    - CUSTOM_JDK="openjdk7"
+
+# Disable OpenJDK7 temporarily because of Travis bug.
+# https://github.com/travis-ci/travis-ci/issues/5227
+# - CUSTOM_JDK="openjdk7"
 
 matrix:
   exclude:

--- a/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
@@ -251,7 +251,7 @@ public class WindowedWordCount {
           .to(getTableReference(options))
           .withSchema(getSchema())
           .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
-          .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE));
+          .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND));
 
     PipelineResult result = pipeline.run();
 


### PR DESCRIPTION
1. Disable Travis container builds, and revert to older process. See bug: https://github.com/travis-ci/travis-ci/issues/3396
2. Temporarily disable OpenJDK7 tests, because they are broken. Prefer to disable OpenJDK7 (we still have OracleJDK7) over the workarounds in linked bug because they're more invasive hacks. https://github.com/travis-ci/travis-ci/issues/5227