### PR TITLE
Disable Maven forking in Travis-CI to fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,29 +9,18 @@ notifications:
     on_success: change
     on_failure: always
 
-os:
-  - linux
-  - osx
-
-env:
-  matrix:
-    - CUSTOM_JDK="default"
-    - CUSTOM_JDK="oraclejdk8"
-    - CUSTOM_JDK="oraclejdk7"
-    - CUSTOM_JDK="openjdk7"
-
 matrix:
-  exclude:
-     # On OSX, run with default JDK only.
-     - os: osx
-       env: CUSTOM_JDK="oraclejdk8"
-     - os: osx
-       env: CUSTOM_JDK="oraclejdk7"
-     - os: osx
-       env: CUSTOM_JDK="openjdk7"
-     # On Linux, run with specific JDKs only.
-     - os: linux
-       env: CUSTOM_JDK="default"
+  include:
+    # On OSX, run with default JDK only.
+    - os: osx
+      env: MAVEN_OVERRIDE=""
+    # On Linux, run with specific JDKs only.
+    - os: linux
+      env: CUSTOM_JDK="oraclejdk8" MAVEN_OVERRIDE="-DforkCount=0"
+    - os: linux
+      env: CUSTOM_JDK="oraclejdk7" MAVEN_OVERRIDE="-DforkCount=0"
+    - os: linux
+      env: CUSTOM_JDK="openjdk7" MAVEN_OVERRIDE="-DforkCount=0"
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
@@ -42,5 +31,5 @@ install:
 
 script:
   - travis_retry mvn versions:set -DnewVersion=manual_build
-  - travis_retry mvn install -U
+  - travis_retry mvn $MAVEN_OVERRIDE install -U
   - travis_retry travis/test_wordcount.sh

--- a/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
@@ -251,7 +251,7 @@ public class WindowedWordCount {
           .to(getTableReference(options))
           .withSchema(getSchema())
           .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
-          .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE));
+          .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND));
 
     PipelineResult result = pipeline.run();
 


### PR DESCRIPTION
* See travis-ci/travis-ci#3396. Basically, there's an error that does not properly pass -Xmx and similar arguments to the forked JVMs that Javadoc, Surefire, and other plugins invoke. This bug causes the forked JVMs to exceed the container's RAM limit, the JVMs to get killed, and the builds to fail.

    Disabling the forking by setting `-DforkCount=0` in the Maven command seems to have resolved the issue, and it does not slow down build time much.

* However, the underlying bug seems to only affect Linux VMs, and not OS X. Additionally, disabling forking in the OS X tests causes them to fail for another lingering Travis issue (PermSize in OS X). So, I rewrote the test matrix to only disable forking with the above argument for Linux tests.

* In the cleanup, I rewrote the test matrix for Travis to be simpler and cleaner.