### PR TITLE
Proposing changes to support HBase Sequence Files.

### DIFF
--- a/contrib/hadoop/pom.xml
+++ b/contrib/hadoop/pom.xml
@@ -165,5 +165,11 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Proposing following changes to HadoopFileSource:
1. Allow user to override the output coder. 
2. Allow user to pass configuration properties to the file Reader. For example, hbase.import.version, 
   which decides  what version of Result's Deserializer is used. User may also choose to pass 
   gcs-connector configs this way  instead of putting them in core-site.xml
3. Allow user to turn off input file access by the source from the starting host. See HadoopFileSource#setIsRemoteFileFromLaunchSite() for motivation.

A copy of this HadoopFileSource with the proposed changes is used here:
https://github.com/GoogleCloudPlatform/cloud-bigtable-client/tree/master/bigtable-dataflow-import/src/main/java/com/google/cloud/bigtable/dataflowimport
