### PR TITLE
Give root transforms step names

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ConsumerTrackingPipelineVisitor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ConsumerTrackingPipelineVisitor.java
@@ -74,12 +74,12 @@ public class ConsumerTrackingPipelineVisitor implements PipelineVisitor {
   public void visitTransform(TransformTreeNode node) {
     toFinalize.removeAll(node.getInput().expand());
     AppliedPTransform<?, ?, ?> appliedTransform = getAppliedTransform(node);
+    stepNames.put(appliedTransform, genStepName());
     if (node.getInput().expand().isEmpty()) {
       rootTransforms.add(appliedTransform);
     } else {
       for (PValue value : node.getInput().expand()) {
         valueToConsumers.get(value).add(appliedTransform);
-        stepNames.put(appliedTransform, genStepName());
       }
     }
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ConsumerTrackingPipelineVisitorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ConsumerTrackingPipelineVisitorTest.java
@@ -175,6 +175,43 @@ public class ConsumerTrackingPipelineVisitorTest implements Serializable {
   }
 
   @Test
+  public void getStepNamesContainsAllTransforms() {
+    PCollection<String> created = p.apply(Create.of("1", "2", "3"));
+    PCollection<String> transformed =
+        created.apply(
+            ParDo.of(
+                new DoFn<String, String>() {
+                  @Override
+                  public void processElement(DoFn<String, String>.ProcessContext c)
+                      throws Exception {
+                    c.output(Integer.toString(c.element().length()));
+                  }
+                }));
+    PDone finished =
+        transformed.apply(
+            new PTransform<PInput, PDone>() {
+              @Override
+              public PDone apply(PInput input) {
+                return PDone.in(input.getPipeline());
+              }
+            });
+
+    p.traverseTopologically(visitor);
+    assertThat(
+        visitor.getStepNames(),
+        Matchers.<AppliedPTransform<?, ?, ?>, String>hasEntry(
+            created.getProducingTransformInternal(), "s0"));
+    assertThat(
+        visitor.getStepNames(),
+        Matchers.<AppliedPTransform<?, ?, ?>, String>hasEntry(
+            transformed.getProducingTransformInternal(), "s1"));
+    assertThat(
+        visitor.getStepNames(),
+        Matchers.<AppliedPTransform<?, ?, ?>, String>hasEntry(
+            finished.getProducingTransformInternal(), "s2"));
+  }
+
+  @Test
   public void traverseMultipleTimesThrows() {
     p.apply(Create.of(1, 2, 3));
 

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContextTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContextTest.java
@@ -71,7 +71,6 @@ import org.junit.runners.JUnit4;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -88,7 +87,8 @@ public class InProcessEvaluationContextTest {
   private PCollection<KV<String, Integer>> downstream;
   private PCollectionView<Iterable<Integer>> view;
   private PCollection<Long> unbounded;
-
+  private Collection<AppliedPTransform<?, ?, ?>> rootTransforms;
+  private Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers;
 
   @Before
   public void setup() {
@@ -101,31 +101,19 @@ public class InProcessEvaluationContextTest {
     downstream = created.apply(WithKeys.<String, Integer>of("foo"));
     view = created.apply(View.<Integer>asIterable());
     unbounded = p.apply(CountingInput.unbounded());
-    Collection<AppliedPTransform<?, ?, ?>> rootTransforms =
-        ImmutableList.<AppliedPTransform<?, ?, ?>>of(
-            created.getProducingTransformInternal(), unbounded.getProducingTransformInternal());
-    Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers = new HashMap<>();
-    valueToConsumers.put(
-        created,
-        ImmutableList.<AppliedPTransform<?, ?, ?>>of(
-            downstream.getProducingTransformInternal(), view.getProducingTransformInternal()));
-    valueToConsumers.put(unbounded, ImmutableList.<AppliedPTransform<?, ?, ?>>of());
-    valueToConsumers.put(downstream, ImmutableList.<AppliedPTransform<?, ?, ?>>of());
-    valueToConsumers.put(view, ImmutableList.<AppliedPTransform<?, ?, ?>>of());
 
-    Map<AppliedPTransform<?, ?, ?>, String> stepNames = new HashMap<>();
-    stepNames.put(created.getProducingTransformInternal(), "s1");
-    stepNames.put(downstream.getProducingTransformInternal(), "s2");
-    stepNames.put(view.getProducingTransformInternal(), "s3");
-    stepNames.put(unbounded.getProducingTransformInternal(), "s4");
+    ConsumerTrackingPipelineVisitor cVis = new ConsumerTrackingPipelineVisitor();
+    p.traverseTopologically(cVis);
+    rootTransforms = cVis.getRootTransforms();
+    valueToConsumers = cVis.getValueToConsumers();
 
-    Collection<PCollectionView<?>> views = ImmutableList.<PCollectionView<?>>of(view);
-    context = InProcessEvaluationContext.create(
+    context =
+        InProcessEvaluationContext.create(
             runner.getPipelineOptions(),
             rootTransforms,
             valueToConsumers,
-            stepNames,
-            views);
+            cVis.getStepNames(),
+            cVis.getViews());
   }
 
   @Test
@@ -490,16 +478,14 @@ public class InProcessEvaluationContextTest {
         null,
         ImmutableList.<TimerData>of(),
         StepTransformResult.withoutHold(unbounded.getProducingTransformInternal()).build());
-    context.handleResult(
-        committedBundle,
-        ImmutableList.<TimerData>of(),
-        StepTransformResult.withoutHold(downstream.getProducingTransformInternal()).build());
     assertThat(context.isDone(), is(false));
 
-    context.handleResult(
-        committedBundle,
-        ImmutableList.<TimerData>of(),
-        StepTransformResult.withoutHold(view.getProducingTransformInternal()).build());
+    for (AppliedPTransform<?, ?, ?> consumers : valueToConsumers.get(created)) {
+      context.handleResult(
+          committedBundle,
+          ImmutableList.<TimerData>of(),
+          StepTransformResult.withoutHold(consumers).build());
+    }
     assertThat(context.isDone(), is(true));
   }
 


### PR DESCRIPTION
Fix a bug where steps would only be given step names if they were a
non-root node.

Use the ConsumerTrackingPipelineVisitor in the
InProcessEvaluationContext test to handle runner-expanded transforms

This backports [Beam #113](https://github.com/apache/incubator-beam/pull/113)