### PR TITLE
Add WindowIntoEvaluatorFactory

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/PassthroughTransformEvaluator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/PassthroughTransformEvaluator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
+import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+
+class PassthroughTransformEvaluator<InputT> implements TransformEvaluator<InputT> {
+  public static <InputT> PassthroughTransformEvaluator<InputT> create(
+      AppliedPTransform<?, ?, ?> transform, UncommittedBundle<InputT> output) {
+    return new PassthroughTransformEvaluator<>(transform, output);
+  }
+
+  private final AppliedPTransform<?, ?, ?> transform;
+  private final UncommittedBundle<InputT> output;
+
+  private PassthroughTransformEvaluator(
+      AppliedPTransform<?, ?, ?> transform, UncommittedBundle<InputT> output) {
+    this.transform = transform;
+    this.output = output;
+  }
+
+  @Override
+  public void processElement(WindowedValue<InputT> element) throws Exception {
+    output.add(element);
+  }
+
+  @Override
+  public InProcessTransformResult finishBundle() throws Exception {
+    return StepTransformResult.withoutHold(transform).addOutput(output).build();
+  }
+
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorRegistry.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorRegistry.java
@@ -21,6 +21,7 @@ import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.transforms.Flatten.FlattenPCollectionList;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -45,6 +46,7 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
                 new GroupByKeyEvaluatorFactory())
             .put(FlattenPCollectionList.class, new FlattenEvaluatorFactory())
             .put(ViewEvaluatorFactory.WriteView.class, new ViewEvaluatorFactory())
+            .put(Window.Bound.class, new WindowEvaluatorFactory())
             .build();
     return new TransformEvaluatorRegistry(primitives);
   }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/WindowEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/WindowEvaluatorFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
+import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window.Bound;
+import com.google.cloud.dataflow.sdk.transforms.windowing.WindowFn;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+
+import org.joda.time.Instant;
+
+import java.util.Collection;
+
+import javax.annotation.Nullable;
+
+/**
+ * The {@link InProcessPipelineRunner} {@link TransformEvaluatorFactory} for the
+ * {@link Bound Window.Bound} primitive {@link PTransform}.
+ */
+class WindowEvaluatorFactory implements TransformEvaluatorFactory {
+
+  @Override
+  public <InputT> TransformEvaluator<InputT> forApplication(
+      AppliedPTransform<?, ?, ?> application,
+      @Nullable CommittedBundle<?> inputBundle,
+      InProcessEvaluationContext evaluationContext)
+      throws Exception {
+    return createTransformEvaluator(
+        (AppliedPTransform) application, inputBundle, evaluationContext);
+  }
+
+  private <InputT> TransformEvaluator<InputT> createTransformEvaluator(
+      AppliedPTransform<PCollection<InputT>, PCollection<InputT>, Window.Bound<InputT>> transform,
+      CommittedBundle<?> inputBundle,
+      InProcessEvaluationContext evaluationContext) {
+    WindowFn<? super InputT, ?> fn = transform.getTransform().getWindowFn();
+    UncommittedBundle<InputT> outputBundle =
+        evaluationContext.createBundle(inputBundle, transform.getOutput());
+    if (fn == null) {
+      return PassthroughTransformEvaluator.create(transform, outputBundle);
+    }
+    return new WindowIntoEvaluator<>(fn, evaluationContext, outputBundle);
+  }
+
+  private static class WindowIntoEvaluator<InputT> implements TransformEvaluator<InputT> {
+    private final WindowFn<InputT, ?> windowFn;
+    private final InProcessEvaluationContext context;
+    private final UncommittedBundle<InputT> outputBundle;
+
+    @SuppressWarnings("unchecked")
+    public WindowIntoEvaluator(
+        WindowFn<? super InputT, ?> windowFn,
+        InProcessEvaluationContext context,
+        UncommittedBundle<InputT> outputBundle) {
+      // Safe contravariant cast
+      this.windowFn = (WindowFn<InputT, ?>) windowFn;
+      this.context = context;
+      this.outputBundle = outputBundle;
+    }
+
+    @Override
+    public void processElement(WindowedValue<InputT> element) throws Exception {
+      Collection<? extends BoundedWindow> windows = assignWindows(windowFn, element);
+      outputBundle.add(
+          WindowedValue.<InputT>of(
+              element.getValue(), element.getTimestamp(), windows, PaneInfo.NO_FIRING));
+    }
+
+    private <W extends BoundedWindow> Collection<? extends BoundedWindow> assignWindows(
+        WindowFn<InputT, W> windowFn, WindowedValue<InputT> element) throws Exception {
+      WindowFn<InputT, W>.AssignContext assignContext =
+          new InProcessAssignContext<>(windowFn, element);
+      Collection<? extends BoundedWindow> windows = windowFn.assignWindows(assignContext);
+      return windows;
+    }
+
+    @Override
+    public InProcessTransformResult finishBundle() throws Exception {
+      return StepTransformResult.withoutHold(null).addOutput(outputBundle).build();
+    }
+  }
+
+  private static class InProcessAssignContext<InputT, W extends BoundedWindow>
+      extends WindowFn<InputT, W>.AssignContext {
+    private final WindowedValue<InputT> value;
+
+    public InProcessAssignContext(WindowFn<InputT, W> fn, WindowedValue<InputT> value) {
+      fn.super();
+      this.value = value;
+    }
+
+    @Override
+    public InputT element() {
+      return value.getValue();
+    }
+
+    @Override
+    public Instant timestamp() {
+      return value.getTimestamp();
+    }
+
+    @Override
+    public Collection<? extends BoundedWindow> windows() {
+      return value.getWindows();
+    }
+
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/WindowEvaluatorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/WindowEvaluatorFactoryTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
+import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.windowing.AfterPane;
+import com.google.cloud.dataflow.sdk.transforms.windowing.AfterWatermark;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.FixedWindows;
+import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo;
+import com.google.cloud.dataflow.sdk.transforms.windowing.SlidingWindows;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window.Bound;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+import org.hamcrest.Matchers;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link WindowEvaluatorFactory}.
+ */
+@RunWith(JUnit4.class)
+public class WindowEvaluatorFactoryTest {
+  private static final Instant EPOCH = new Instant(0);
+
+  private PCollection<Long> input;
+  private WindowEvaluatorFactory factory;
+
+  @Mock private InProcessEvaluationContext evaluationContext;
+
+  private BundleFactory bundleFactory;
+
+  private WindowedValue<Long> first =
+      WindowedValue.timestampedValueInGlobalWindow(3L, new Instant(2L));
+  private WindowedValue<Long> second =
+      WindowedValue.timestampedValueInGlobalWindow(
+          Long.valueOf(1L), EPOCH.plus(Duration.standardDays(3)));
+  private WindowedValue<Long> third =
+      WindowedValue.of(
+          Long.valueOf(2L),
+          new Instant(-10L),
+          new IntervalWindow(new Instant(-100), EPOCH),
+          PaneInfo.NO_FIRING);
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    TestPipeline p = TestPipeline.create();
+    input = p.apply(Create.of(1L, 2L, 3L));
+
+    bundleFactory = InProcessBundleFactory.create();
+    factory = new WindowEvaluatorFactory();
+  }
+
+  @Test
+  public void nullWindowFunSucceeds() throws Exception {
+    Bound<Long> transform =
+        Window.<Long>triggering(
+                AfterWatermark.pastEndOfWindow().withEarlyFirings(AfterPane.elementCountAtLeast(1)))
+            .accumulatingFiredPanes();
+    PCollection<Long> triggering = input.apply(transform);
+
+    CommittedBundle<Long> inputBundle = createInputBundle();
+
+    UncommittedBundle<Long> outputBundle = createOutputBundle(triggering, inputBundle);
+
+    InProcessTransformResult result = runEvaluator(triggering, inputBundle, transform);
+
+    assertThat(
+        Iterables.getOnlyElement(result.getOutputBundles()),
+        Matchers.<UncommittedBundle<?>>equalTo(outputBundle));
+    CommittedBundle<Long> committed = outputBundle.commit(Instant.now());
+    assertThat(committed.getElements(), containsInAnyOrder(third, first, second));
+  }
+
+  @Test
+  public void singleWindowFnSucceeds() throws Exception {
+    Duration windowDuration = Duration.standardDays(7);
+    Bound<Long> transform = Window.<Long>into(FixedWindows.of(windowDuration));
+    PCollection<Long> windowed = input.apply(transform);
+
+    CommittedBundle<Long> inputBundle = createInputBundle();
+
+    UncommittedBundle<Long> outputBundle = createOutputBundle(windowed, inputBundle);
+
+    BoundedWindow firstSecondWindow = new IntervalWindow(EPOCH, EPOCH.plus(windowDuration));
+    BoundedWindow thirdWindow = new IntervalWindow(EPOCH.minus(windowDuration), EPOCH);
+
+    InProcessTransformResult result = runEvaluator(windowed, inputBundle, transform);
+
+    assertThat(
+        Iterables.getOnlyElement(result.getOutputBundles()),
+        Matchers.<UncommittedBundle<?>>equalTo(outputBundle));
+    CommittedBundle<Long> committed = outputBundle.commit(Instant.now());
+
+    WindowedValue<Long> expectedNewFirst =
+        WindowedValue.of(3L, new Instant(2L), firstSecondWindow, PaneInfo.NO_FIRING);
+    WindowedValue<Long> expectedNewSecond =
+        WindowedValue.of(
+            1L, EPOCH.plus(Duration.standardDays(3)), firstSecondWindow, PaneInfo.NO_FIRING);
+    WindowedValue<Long> expectedNewThird =
+        WindowedValue.of(2L, new Instant(-10L), thirdWindow, PaneInfo.NO_FIRING);
+    assertThat(
+        committed.getElements(),
+        containsInAnyOrder(expectedNewFirst, expectedNewSecond, expectedNewThird));
+  }
+
+  @Test
+  public void multipleWindowsWindowFnSucceeds() throws Exception {
+    Duration windowDuration = Duration.standardDays(6);
+    Duration slidingBy = Duration.standardDays(3);
+    Bound<Long> transform = Window.into(SlidingWindows.of(windowDuration).every(slidingBy));
+    PCollection<Long> windowed = input.apply(transform);
+
+    CommittedBundle<Long> inputBundle = createInputBundle();
+    UncommittedBundle<Long> outputBundle = createOutputBundle(windowed, inputBundle);
+
+    InProcessTransformResult result = runEvaluator(windowed, inputBundle, transform);
+
+    assertThat(
+        Iterables.getOnlyElement(result.getOutputBundles()),
+        Matchers.<UncommittedBundle<?>>equalTo(outputBundle));
+    CommittedBundle<Long> committed = outputBundle.commit(Instant.now());
+
+    BoundedWindow w1 = new IntervalWindow(EPOCH, EPOCH.plus(windowDuration));
+    BoundedWindow w2 =
+        new IntervalWindow(EPOCH.plus(slidingBy), EPOCH.plus(slidingBy).plus(windowDuration));
+    BoundedWindow wMinus1 = new IntervalWindow(EPOCH.minus(windowDuration), EPOCH);
+    BoundedWindow wMinusSlide =
+        new IntervalWindow(EPOCH.minus(windowDuration).plus(slidingBy), EPOCH.plus(slidingBy));
+
+    WindowedValue<Long> expectedFirst =
+        WindowedValue.of(
+            first.getValue(),
+            first.getTimestamp(),
+            ImmutableSet.of(w1, wMinusSlide),
+            PaneInfo.NO_FIRING);
+    WindowedValue<Long> expectedSecond =
+        WindowedValue.of(
+            second.getValue(), second.getTimestamp(), ImmutableSet.of(w1, w2), PaneInfo.NO_FIRING);
+    WindowedValue<Long> expectedThird =
+        WindowedValue.of(
+            third.getValue(),
+            third.getTimestamp(),
+            ImmutableSet.of(wMinus1, wMinusSlide),
+            PaneInfo.NO_FIRING);
+
+    assertThat(
+        committed.getElements(), containsInAnyOrder(expectedFirst, expectedSecond, expectedThird));
+  }
+
+  private CommittedBundle<Long> createInputBundle() {
+    CommittedBundle<Long> inputBundle =
+        bundleFactory
+            .createRootBundle(input)
+            .add(first)
+            .add(second)
+            .add(third)
+            .commit(Instant.now());
+    return inputBundle;
+  }
+
+  private UncommittedBundle<Long> createOutputBundle(
+      PCollection<Long> output, CommittedBundle<Long> inputBundle) {
+    UncommittedBundle<Long> outputBundle = bundleFactory.createBundle(inputBundle, output);
+    when(evaluationContext.createBundle(inputBundle, output)).thenReturn(outputBundle);
+    return outputBundle;
+  }
+
+  private InProcessTransformResult runEvaluator(
+      PCollection<Long> windowed,
+      CommittedBundle<Long> inputBundle,
+      Window.Bound<Long> windowTransform /* Required while Window.Bound is a composite */)
+      throws Exception {
+    TransformEvaluator<Long> evaluator =
+        factory.forApplication(
+            AppliedPTransform.of("Window", input, windowed, windowTransform),
+            inputBundle,
+            evaluationContext);
+
+    evaluator.processElement(first);
+    evaluator.processElement(second);
+    evaluator.processElement(third);
+    InProcessTransformResult result = evaluator.finishBundle();
+    return result;
+  }
+}


### PR DESCRIPTION
This is a TransformEvaluator-based implementation of the Window#into
primitive, as opposed to the DoFn ProcessContext internals-based
implementation.

This backports [BEAM #149](https://github.com/apache/incubator-beam/pull/149)