### PR TITLE
[BEAM-188] Write: apply GlobalWindows first

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/Write.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/Write.java
@@ -32,8 +32,6 @@ import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PCollectionView;
 import com.google.cloud.dataflow.sdk.values.PDone;
 
-import org.joda.time.Instant;
-
 import java.util.UUID;
 
 /**
@@ -151,6 +149,7 @@ public class Write {
       // There is a dependency between this ParDo and the first (the WriteOperation PCollection
       // as a side input), so this will happen after the initial ParDo.
       PCollection<WriteT> results = input
+          .apply(Window.<T>into(new GlobalWindows()))
           .apply("WriteBundles", ParDo.of(new DoFn<T, WriteT>() {
             // Writer that will write the records in this bundle. Lazily
             // initialized in processElement.
@@ -181,13 +180,11 @@ public class Write {
             public void finishBundle(Context c) throws Exception {
               if (writer != null) {
                 WriteT result = writer.close();
-                // Output the result of the write.
-                c.outputWithTimestamp(result, Instant.now());
+                c.output(result);
               }
             }
           }).withSideInputs(writeOperationView))
-          .setCoder(writeOperation.getWriterResultCoder())
-          .apply(Window.<WriteT>into(new GlobalWindows()));
+          .setCoder(writeOperation.getWriterResultCoder());
 
       final PCollectionView<Iterable<WriteT>> resultsView =
           results.apply(View.<WriteT>asIterable());

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/WriteTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/WriteTest.java
@@ -32,8 +32,16 @@ import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryTest.TestPipelineOptions;
 import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
+import com.google.cloud.dataflow.sdk.transforms.MapElements;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.SimpleFunction;
 import com.google.cloud.dataflow.sdk.transforms.windowing.FixedWindows;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Sessions;
 import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
+import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.common.base.MoreObjects;
 
@@ -50,6 +58,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Tests for the Write PTransform.
@@ -57,7 +66,47 @@ import java.util.UUID;
 @RunWith(JUnit4.class)
 public class WriteTest {
   // Static store that can be accessed within the writer
-  static List<String> sinkContents = new ArrayList<>();
+  private static List<String> sinkContents = new ArrayList<>();
+
+  private static final MapElements<String, String> IDENTITY_MAP =
+      MapElements.via(new SimpleFunction<String, String>() {
+        @Override
+        public String apply(String input) {
+          return input;
+        }
+      });
+
+  private static class WindowAndReshuffle<T> extends PTransform<PCollection<T>, PCollection<T>> {
+    private final Window.Bound<T> window;
+    public WindowAndReshuffle(Window.Bound<T> window) {
+      this.window = window;
+    }
+
+    private static class AddArbitraryKey<T> extends DoFn<T, KV<Integer, T>> {
+      @Override
+      public void processElement(ProcessContext c) throws Exception {
+        c.output(KV.of(ThreadLocalRandom.current().nextInt(), c.element()));
+      }
+    }
+
+    private static class RemoveArbitraryKey<T> extends DoFn<KV<Integer, Iterable<T>>, T> {
+      @Override
+      public void processElement(ProcessContext c) throws Exception {
+        for (T s : c.element().getValue()) {
+          c.output(s);
+        }
+      }
+    }
+
+    @Override
+    public PCollection<T> apply(PCollection<T> input) {
+      return input
+          .apply(window)
+          .apply(ParDo.of(new AddArbitraryKey<T>()))
+          .apply(GroupByKey.<Integer, T>create())
+          .apply(ParDo.of(new RemoveArbitraryKey<T>()));
+    }
+  }
 
   /**
    * Test a Write transform with a PCollection of elements.
@@ -66,7 +115,7 @@ public class WriteTest {
   public void testWrite() {
     List<String> inputs = Arrays.asList("Critical canary", "Apprehensive eagle",
         "Intimidating pigeon", "Pedantic gull", "Frisky finch");
-    runWrite(inputs, /* not windowed */ false);
+    runWrite(inputs, IDENTITY_MAP);
   }
 
   /**
@@ -75,7 +124,7 @@ public class WriteTest {
   @Test
   public void testWriteWithEmptyPCollection() {
     List<String> inputs = new ArrayList<>();
-    runWrite(inputs, /* not windowed */ false);
+    runWrite(inputs, IDENTITY_MAP);
   }
 
   /**
@@ -85,7 +134,21 @@ public class WriteTest {
   public void testWriteWindowed() {
     List<String> inputs = Arrays.asList("Critical canary", "Apprehensive eagle",
         "Intimidating pigeon", "Pedantic gull", "Frisky finch");
-    runWrite(inputs, /* windowed */ true);
+    runWrite(
+        inputs, new WindowAndReshuffle(Window.<String>into(FixedWindows.of(Duration.millis(2)))));
+  }
+
+  /**
+   * Test a Write with sessions.
+   */
+  @Test
+  public void testWriteWithSessions() {
+    List<String> inputs = Arrays.asList("Critical canary", "Apprehensive eagle",
+        "Intimidating pigeon", "Pedantic gull", "Frisky finch");
+
+    runWrite(
+        inputs,
+        new WindowAndReshuffle(Window.<String>into(Sessions.withGapDuration(Duration.millis(1)))));
   }
 
   /**
@@ -93,7 +156,8 @@ public class WriteTest {
    * a test sink in the correct order, as well as verifies that the elements of a PCollection are
    * written to the sink.
    */
-  public void runWrite(List<String> inputs, boolean windowed) {
+  private static void runWrite(
+      List<String> inputs, PTransform<PCollection<String>, PCollection<String>> transform) {
     // Flag to validate that the pipeline options are passed to the Sink
     String[] args = {"--testFlag=test_value"};
     PipelineOptions options = PipelineOptionsFactory.fromArgs(args).as(WriteOptions.class);
@@ -102,21 +166,16 @@ public class WriteTest {
     // Clear the sink's contents.
     sinkContents.clear();
 
-    // Construct the input PCollection and test Sink.
-    PCollection<String> input;
-    if (windowed) {
-      List<Long> timestamps = new ArrayList<>();
-      for (long i = 0; i < inputs.size(); i++) {
-        timestamps.add(i + 1);
-      }
-      input = p.apply(Create.timestamped(inputs, timestamps).withCoder(StringUtf8Coder.of()))
-               .apply(Window.<String>into(FixedWindows.of(new Duration(2))));
-    } else {
-      input = p.apply(Create.of(inputs).withCoder(StringUtf8Coder.of()));
+    // Prepare timestamps for the elements.
+    List<Long> timestamps = new ArrayList<>();
+    for (long i = 0; i < inputs.size(); i++) {
+      timestamps.add(i + 1);
     }
-    TestSink sink = new TestSink();
 
-    input.apply(Write.to(sink));
+    TestSink sink = new TestSink();
+    p.apply(Create.timestamped(inputs, timestamps).withCoder(StringUtf8Coder.of()))
+     .apply(transform)
+     .apply(Write.to(sink));
 
     p.run();
     assertThat(sinkContents, containsInAnyOrder(inputs.toArray()));


### PR DESCRIPTION
And do not supply a timestamp when outputting.

Note that this is safe because the functions in the Writer cannot access the window
or timestamp. When we add per-Window or similar functions to the sinks, we will
likely do so at a higher level.

This is a backport of apache/incubator-beam#188