### PR TITLE
Track pending elements via exploded WindowedValues

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
@@ -27,9 +27,11 @@ import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PValue;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -206,7 +208,7 @@ public class InMemoryWatermarkManager {
 
     public AppliedPTransformInputWatermark(Collection<? extends Watermark> inputWatermarks) {
       this.inputWatermarks = inputWatermarks;
-      this.pendingElements = TreeMultiset.create(PENDING_ELEMENT_COMPARATOR);
+      this.pendingElements = TreeMultiset.create(new WindowedValueByTimestampComparator());
       this.objectTimers = new HashMap<>();
       currentWatermark = new AtomicReference<>(BoundedWindow.TIMESTAMP_MIN_VALUE);
     }
@@ -620,12 +622,17 @@ public class InMemoryWatermarkManager {
   private static final Ordering<Instant> INSTANT_ORDERING = Ordering.natural();
 
   /**
-   * An ordering that compares windowed values by timestamp, then arbitrarily. This ensures that
-   * {@link WindowedValue WindowedValues} will be sorted by timestamp, while two different
-   * {@link WindowedValue WindowedValues} with the same timestamp are not considered equal.
+   * A function that takes a WindowedValue and returns the exploded representation of that
+   * {@link WindowedValue}.
    */
-  private static final Ordering<WindowedValue<? extends Object>> PENDING_ELEMENT_COMPARATOR =
-      (new WindowedValueByTimestampComparator()).compound(Ordering.arbitrary());
+  private static final Function<WindowedValue<?>, ? extends Iterable<? extends WindowedValue<?>>>
+      EXPLODE_WINDOWS_FN =
+          new Function<WindowedValue<?>, Iterable<? extends WindowedValue<?>>>() {
+            @Override
+            public Iterable<? extends WindowedValue<?>> apply(WindowedValue<?> input) {
+              return input.explodeWindows();
+            }
+          };
 
   /**
    * For each (Object, PriorityQueue) pair in the provided map, remove each Timer that is before the
@@ -1044,13 +1051,17 @@ public class InMemoryWatermarkManager {
     }
 
     private void removePending(CommittedBundle<?> bundle) {
-      inputWatermark.removePendingElements(bundle.getElements());
+      inputWatermark.removePendingElements(elementsFromBundle(bundle));
       synchronizedProcessingInputWatermark.removePending(bundle);
     }
 
     private void addPending(CommittedBundle<?> bundle) {
-      inputWatermark.addPendingElements(bundle.getElements());
+      inputWatermark.addPendingElements(elementsFromBundle(bundle));
       synchronizedProcessingInputWatermark.addPending(bundle);
+    }
+
+    private Iterable<? extends WindowedValue<?>> elementsFromBundle(CommittedBundle<?> bundle) {
+      return FluentIterable.from(bundle.getElements()).transformAndConcat(EXPLODE_WINDOWS_FN);
     }
 
     private Map<Object, FiredTimers> extractFiredTimers() {
@@ -1294,7 +1305,9 @@ public class InMemoryWatermarkManager {
   private static class WindowedValueByTimestampComparator extends Ordering<WindowedValue<?>> {
     @Override
     public int compare(WindowedValue<?> o1, WindowedValue<?> o2) {
-      return o1.getTimestamp().compareTo(o2.getTimestamp());
+      return ComparisonChain.start()
+          .compare(o1.getTimestamp(), o2.getTimestamp())
+          .result();
     }
   }
 

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
@@ -38,6 +38,9 @@ import com.google.cloud.dataflow.sdk.transforms.Flatten;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.transforms.WithKeys;
 import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo;
 import com.google.cloud.dataflow.sdk.util.TimeDomain;
 import com.google.cloud.dataflow.sdk.util.TimerInternals.TimerData;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
@@ -152,7 +155,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
    */
   @Test
   public void getWatermarkForUpdatedSourceTransform() {
-    CommittedBundle<Integer> output = globallyWindowedBundle(createdInts, 1);
+    CommittedBundle<Integer> output = multiWindowedBundle(createdInts, 1);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.<CommittedBundle<?>>singleton(output), new Instant(8000L));
     TransformWatermarks updatedSourceWatermark =
@@ -167,7 +170,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
    */
   @Test
   public void getWatermarkForMultiInputTransform() {
-    CommittedBundle<Integer> secondPcollectionBundle = globallyWindowedBundle(intsToFlatten, -1);
+    CommittedBundle<Integer> secondPcollectionBundle = multiWindowedBundle(intsToFlatten, -1);
 
     manager.updateWatermarks(null, intsToFlatten.getProducingTransformInternal(),
         TimerUpdate.empty(), Collections.<CommittedBundle<?>>singleton(secondPcollectionBundle),
@@ -196,7 +199,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     assertThat(
         transformWatermark.getOutputWatermark(), not(laterThan(BoundedWindow.TIMESTAMP_MIN_VALUE)));
 
-    CommittedBundle<Integer> flattenedBundleSecondCreate = globallyWindowedBundle(flattened, -1);
+    CommittedBundle<Integer> flattenedBundleSecondCreate = multiWindowedBundle(flattened, -1);
     // We have finished processing the bundle from the second PCollection, but we haven't consumed
     // anything from the first PCollection yet; so our watermark shouldn't advance
     manager.updateWatermarks(secondPcollectionBundle, flattened.getProducingTransformInternal(),
@@ -494,13 +497,39 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         TimerUpdate.empty(), Collections.<CommittedBundle<?>>singleton(lateKeyedBundle), null);
   }
 
+  public void updateWatermarkWithDifferentWindowedValueInstances() {
+    manager.updateWatermarks(
+        null,
+        createdInts.getProducingTransformInternal(),
+        TimerUpdate.empty(),
+        Collections.<CommittedBundle<?>>singleton(
+            bundleFactory
+                .createRootBundle(createdInts)
+                .add(WindowedValue.valueInGlobalWindow(1))
+                .commit(Instant.now())),
+        BoundedWindow.TIMESTAMP_MAX_VALUE);
+
+    manager.updateWatermarks(
+        bundleFactory
+            .createRootBundle(createdInts)
+            .add(WindowedValue.valueInGlobalWindow(1))
+            .commit(Instant.now()),
+        keyed.getProducingTransformInternal(),
+        TimerUpdate.empty(),
+        Collections.<CommittedBundle<?>>emptyList(),
+        null);
+    TransformWatermarks onTimeWatermarks =
+        manager.getWatermarks(keyed.getProducingTransformInternal());
+    assertThat(onTimeWatermarks.getInputWatermark(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
+  }
+
   /**
    * Demonstrates that after watermarks of an upstream transform are updated, but no output has been
    * produced, the watermarks of a downstream process are advanced.
    */
   @Test
   public void getWatermarksAfterOnlyEmptyOutput() {
-    CommittedBundle<Integer> emptyCreateOutput = globallyWindowedBundle(createdInts);
+    CommittedBundle<Integer> emptyCreateOutput = multiWindowedBundle(createdInts);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.<CommittedBundle<?>>singleton(emptyCreateOutput),
         BoundedWindow.TIMESTAMP_MAX_VALUE);
@@ -527,11 +556,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
    */
   @Test
   public void getWatermarksAfterHoldAndEmptyOutput() {
-    CommittedBundle<Integer> firstCreateOutput = globallyWindowedBundle(createdInts, 1, 2);
+    CommittedBundle<Integer> firstCreateOutput = multiWindowedBundle(createdInts, 1, 2);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.<CommittedBundle<?>>singleton(firstCreateOutput), new Instant(12_000L));
 
-    CommittedBundle<Integer> firstFilterOutput = globallyWindowedBundle(filtered);
+    CommittedBundle<Integer> firstFilterOutput = multiWindowedBundle(filtered);
     manager.updateWatermarks(firstCreateOutput, filtered.getProducingTransformInternal(),
         TimerUpdate.empty(), Collections.<CommittedBundle<?>>singleton(firstFilterOutput),
         new Instant(10_000L));
@@ -540,7 +569,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     assertThat(firstFilterWatermarks.getInputWatermark(), not(earlierThan(new Instant(12_000L))));
     assertThat(firstFilterWatermarks.getOutputWatermark(), not(laterThan(new Instant(10_000L))));
 
-    CommittedBundle<Integer> emptyCreateOutput = globallyWindowedBundle(createdInts);
+    CommittedBundle<Integer> emptyCreateOutput = multiWindowedBundle(createdInts);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.<CommittedBundle<?>>singleton(emptyCreateOutput),
         BoundedWindow.TIMESTAMP_MAX_VALUE);
@@ -628,7 +657,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
    */
   //  @Test
   public void getSynchronizedProcessingTimeOutputHeldToPendingTimers() {
-    CommittedBundle<Integer> createdBundle = globallyWindowedBundle(createdInts, 1, 2, 4, 8);
+    CommittedBundle<Integer> createdBundle = multiWindowedBundle(createdInts, 1, 2, 4, 8);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.<CommittedBundle<?>>singleton(createdBundle), new Instant(1248L));
 
@@ -639,7 +668,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     Instant initialFilteredWm = filteredWms.getSynchronizedProcessingOutputTime();
     Instant initialFilteredDoubledWm = filteredDoubledWms.getSynchronizedProcessingOutputTime();
 
-    CommittedBundle<Integer> filteredBundle = globallyWindowedBundle(filtered, 2, 8);
+    CommittedBundle<Integer> filteredBundle = multiWindowedBundle(filtered, 2, 8);
     TimerData pastTimer =
         TimerData.of(StateNamespaces.global(), new Instant(250L), TimeDomain.PROCESSING_TIME);
     TimerData futureTimer =
@@ -748,11 +777,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
   @Test
   public void synchronizedProcessingInputTimeIsHeldToUpstreamProcessingTimeTimers() {
-    CommittedBundle<Integer> created = globallyWindowedBundle(createdInts, 1, 2, 3);
+    CommittedBundle<Integer> created = multiWindowedBundle(createdInts, 1, 2, 3);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.<CommittedBundle<?>>singleton(created), new Instant(40_900L));
 
-    CommittedBundle<Integer> filteredBundle = globallyWindowedBundle(filtered, 2, 4);
+    CommittedBundle<Integer> filteredBundle = multiWindowedBundle(filtered, 2, 4);
     Instant upstreamHold = new Instant(2048L);
     TimerData upstreamProcessingTimer =
         TimerData.of(StateNamespaces.global(), upstreamHold, TimeDomain.PROCESSING_TIME);
@@ -773,7 +802,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     // synchronized processing time
     assertThat(downstreamWms.getSynchronizedProcessingInputTime(), equalTo(upstreamHold));
 
-    CommittedBundle<Integer> otherCreated = globallyWindowedBundle(createdInts, 4, 8, 12);
+    CommittedBundle<Integer> otherCreated = multiWindowedBundle(createdInts, 4, 8, 12);
     manager.updateWatermarks(otherCreated, filtered.getProducingTransformInternal(),
         TimerUpdate.builder("key")
             .withCompletedTimers(Collections.singleton(upstreamProcessingTimer))
@@ -785,7 +814,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
   @Test
   public void synchronizedProcessingInputTimeIsHeldToPendingBundleTimes() {
-    CommittedBundle<Integer> created = globallyWindowedBundle(createdInts, 1, 2, 3);
+    CommittedBundle<Integer> created = multiWindowedBundle(createdInts, 1, 2, 3);
     manager.updateWatermarks(
         null,
         createdInts.getProducingTransformInternal(),
@@ -819,7 +848,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     assertThat(initialTimers.entrySet(), emptyIterable());
 
     // Advance WM of keyed past the first timer, but ahead of the second and third
-    CommittedBundle<Integer> createdBundle = globallyWindowedBundle(filtered);
+    CommittedBundle<Integer> createdBundle = multiWindowedBundle(filtered);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.singleton(createdBundle), new Instant(1500L));
 
@@ -837,8 +866,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
             .setTimer(lastTimer)
             .build();
 
-    manager.updateWatermarks(createdBundle, filtered.getProducingTransformInternal(), update,
-        Collections.<CommittedBundle<?>>singleton(globallyWindowedBundle(intsToFlatten)),
+    manager.updateWatermarks(
+        createdBundle,
+        filtered.getProducingTransformInternal(),
+        update,
+        Collections.<CommittedBundle<?>>singleton(multiWindowedBundle(intsToFlatten)),
         new Instant(1000L));
 
     Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firstTransformFiredTimers =
@@ -873,7 +905,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     assertThat(initialTimers.entrySet(), emptyIterable());
 
     // Advance WM of keyed past the first timer, but ahead of the second and third
-    CommittedBundle<Integer> createdBundle = globallyWindowedBundle(filtered);
+    CommittedBundle<Integer> createdBundle = multiWindowedBundle(filtered);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.singleton(createdBundle), new Instant(1500L));
 
@@ -891,8 +923,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
             .setTimer(middleTimer)
             .build();
 
-    manager.updateWatermarks(createdBundle, filtered.getProducingTransformInternal(), update,
-        Collections.<CommittedBundle<?>>singleton(globallyWindowedBundle(intsToFlatten)),
+    manager.updateWatermarks(
+        createdBundle,
+        filtered.getProducingTransformInternal(),
+        update,
+        Collections.<CommittedBundle<?>>singleton(multiWindowedBundle(intsToFlatten)),
         new Instant(1000L));
 
     Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firstTransformFiredTimers =
@@ -928,7 +963,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     assertThat(initialTimers.entrySet(), emptyIterable());
 
     // Advance WM of keyed past the first timer, but ahead of the second and third
-    CommittedBundle<Integer> createdBundle = globallyWindowedBundle(filtered);
+    CommittedBundle<Integer> createdBundle = multiWindowedBundle(filtered);
     manager.updateWatermarks(null, createdInts.getProducingTransformInternal(), TimerUpdate.empty(),
         Collections.singleton(createdBundle), new Instant(1500L));
 
@@ -946,8 +981,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
             .setTimer(middleTimer)
             .build();
 
-    manager.updateWatermarks(createdBundle, filtered.getProducingTransformInternal(), update,
-        Collections.<CommittedBundle<?>>singleton(globallyWindowedBundle(intsToFlatten)),
+    manager.updateWatermarks(
+        createdBundle,
+        filtered.getProducingTransformInternal(),
+        update,
+        Collections.<CommittedBundle<?>>singleton(multiWindowedBundle(intsToFlatten)),
         new Instant(1000L));
 
     Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firstTransformFiredTimers =
@@ -1112,10 +1150,15 @@ public class InMemoryWatermarkManagerTest implements Serializable {
   }
 
   @SafeVarargs
-  private final <T> CommittedBundle<T> globallyWindowedBundle(PCollection<T> pc, T... values) {
+  private final <T> CommittedBundle<T> multiWindowedBundle(PCollection<T> pc, T... values) {
     UncommittedBundle<T> bundle = bundleFactory.createRootBundle(pc);
+    Collection<BoundedWindow> windows =
+        ImmutableList.of(
+            GlobalWindow.INSTANCE,
+            new IntervalWindow(BoundedWindow.TIMESTAMP_MIN_VALUE, new Instant(0)));
     for (T value : values) {
-      bundle.add(WindowedValue.valueInGlobalWindow(value));
+      bundle.add(
+          WindowedValue.of(value, BoundedWindow.TIMESTAMP_MIN_VALUE, windows, PaneInfo.NO_FIRING));
     }
     return bundle.commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
   }


### PR DESCRIPTION
This allows the WindowedValues to be partially completed while the
still holding the watermark.

This backports [BEAM #207](https://github.com/apache/incubator-beam/pull/207)