### PR TITLE
Enforce JobName Preconditions in the Dataflow Runner

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/DataflowPipelineOptions.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/DataflowPipelineOptions.java
@@ -65,8 +65,11 @@ public interface DataflowPipelineOptions extends
    * name will not be able to be created. Defaults to using the ApplicationName-UserName-Date.
    */
   @Description("The Dataflow job name is used as an idempotence key within the Dataflow service. "
-      + "If there is an existing job that is currently active, another active job with the same "
-      + "name will not be able to be created. Defaults to using the ApplicationName-UserName-Date.")
+      + "For each running job in the same GCP project, jobs with the same name cannot be created "
+      + "unless the new job is an explicit update of the previous one. Defaults to using "
+      + "ApplicationName-UserName-Date. The job name must match the regular expression "
+      + "'[a-z]([-a-z0-9]{0,38}[a-z0-9])?'. The runner will automatically truncate the name of the "
+      + "job and convert to lower case.")
   @Default.InstanceFactory(JobNameFactory.class)
   String getJobName();
   void setJobName(String value);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
@@ -288,13 +288,25 @@ public class DataflowPipelineRunner extends PipelineRunner<DataflowPipelineJob> 
       LOG.debug("Classpath elements: {}", dataflowOptions.getFilesToStage());
     }
 
-    // Verify jobName according to service requirements.
-    String jobName = dataflowOptions.getJobName().toLowerCase();
-    Preconditions.checkArgument(
+    // Verify jobName according to service requirements, truncating converting to lowercase if
+    // necessary.
+    String jobName =
+        dataflowOptions
+            .getJobName()
+            .toLowerCase();
+    checkArgument(
         jobName.matches("[a-z]([-a-z0-9]*[a-z0-9])?"),
         "JobName invalid; the name must consist of only the characters "
             + "[-a-z0-9], starting with a letter and ending with a letter "
             + "or number");
+    if (!jobName.equals(dataflowOptions.getJobName())) {
+      LOG.info(
+          "PipelineOptions.jobName did not match the service requirements. "
+              + "Using {} instead of {}.",
+          jobName,
+          dataflowOptions.getJobName());
+    }
+    dataflowOptions.setJobName(jobName);
 
     // Verify project
     String project = dataflowOptions.getProject();

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/BlockingDataflowPipelineRunnerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/BlockingDataflowPipelineRunnerTest.java
@@ -295,7 +295,7 @@ public class BlockingDataflowPipelineRunnerTest {
     options.setTempLocation("gs://test/temp/location");
     options.setGcpCredential(new TestCredential());
     options.setPathValidatorClass(NoopPathValidator.class);
-    assertEquals("BlockingDataflowPipelineRunner#TestJobName",
+    assertEquals("BlockingDataflowPipelineRunner#testjobname",
         BlockingDataflowPipelineRunner.fromOptions(options).toString());
   }
 }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineTest.java
@@ -38,7 +38,7 @@ public class DataflowPipelineTest {
     options.setTempLocation("gs://test/temp/location");
     options.setGcpCredential(new TestCredential());
     options.setPathValidatorClass(NoopPathValidator.class);
-    assertEquals("DataflowPipeline#TestJobName",
+    assertEquals("DataflowPipeline#testjobname" /* lowercased for service requirements */,
         DataflowPipeline.create(options).toString());
   }
 }


### PR DESCRIPTION
This ensures that whenever a DataflowPipelineRunner is created, the
jobName of the created options conforms to the requirements of the
Dataflow Service.

This backports [BEAM #187](https://github.com/apache/incubator-beam/pull/187)
This backports [BEAM #233](https://github.com/apache/incubator-beam/pull/233)