### PR TITLE
Fix CreateSource#getBytesPerOffset

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessCreate.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessCreate.java
@@ -171,9 +171,9 @@ class InProcessCreate<T> extends ForwardingPTransform<PInput, PCollection<T>> {
     @Override
     public long getBytesPerOffset() {
       if (allElementsBytes.size() == 0) {
-        return 0L;
+        return 1L;
       }
-      return totalSize / allElementsBytes.size();
+      return Math.max(1L, totalSize / allElementsBytes.size());
     }
   }
 


### PR DESCRIPTION
Return 1L when there are no elements, as the default value. Return 1L
when the total encoded size of all the elements is 0, for example when
using VoidCoder.

Backports [BEAM-232](https://github.com/apache/incubator-beam/pull/232)