### PR TITLE
Output InProcessGroupByKeyOnly elements in the Global Window

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/GroupByKeyEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/GroupByKeyEvaluatorFactory.java
@@ -147,7 +147,7 @@ class GroupByKeyEvaluatorFactory implements TransformEvaluatorFactory {
             KeyedWorkItems.elementsWorkItem(key, groupedEntry.getValue());
         UncommittedBundle<KeyedWorkItem<K, V>> bundle =
             evaluationContext.createKeyedBundle(inputBundle, key, application.getOutput());
-        bundle.add(WindowedValue.valueInEmptyWindows(groupedKv));
+        bundle.add(WindowedValue.valueInGlobalWindow(groupedKv));
         resultBuilder.addOutput(bundle);
       }
       return resultBuilder.build();


### PR DESCRIPTION
This ensures that the values are not dropped if they are exploded (for
example, in the Watermark Manager).

This backports [BEAM-242](https://github.com/apache/incubator-beam/pull/242)