### PR TITLE
Remove isKeyed property of InProcess Bundles

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleFactory.java
@@ -40,20 +40,18 @@ class InProcessBundleFactory implements BundleFactory {
 
   @Override
   public <T> UncommittedBundle<T> createRootBundle(PCollection<T> output) {
-    return InProcessBundle.unkeyed(output);
+    return InProcessBundle.create(output, null);
   }
 
   @Override
   public <T> UncommittedBundle<T> createBundle(CommittedBundle<?> input, PCollection<T> output) {
-    return input.isKeyed()
-        ? InProcessBundle.keyed(output, input.getKey())
-        : InProcessBundle.unkeyed(output);
+    return InProcessBundle.create(output, input.getKey());
   }
 
   @Override
   public <T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, Object key, PCollection<T> output) {
-    return InProcessBundle.keyed(output, key);
+      CommittedBundle<?> input, @Nullable Object key, PCollection<T> output) {
+    return InProcessBundle.create(output, key);
   }
 
   /**
@@ -61,32 +59,19 @@ class InProcessBundleFactory implements BundleFactory {
    */
   private static final class InProcessBundle<T> implements UncommittedBundle<T> {
     private final PCollection<T> pcollection;
-    private final boolean keyed;
-    private final Object key;
+    @Nullable private final Object key;
     private boolean committed = false;
     private ImmutableList.Builder<WindowedValue<T>> elements;
 
     /**
-     * Create a new {@link InProcessBundle} for the specified {@link PCollection} without a key.
+     * Create a new {@link InProcessBundle} for the specified {@link PCollection}.
      */
-    public static <T> InProcessBundle<T> unkeyed(PCollection<T> pcollection) {
-      return new InProcessBundle<T>(pcollection, false, null);
+    public static <T> InProcessBundle<T> create(PCollection<T> pcollection, @Nullable Object key) {
+      return new InProcessBundle<T>(pcollection, key);
     }
 
-    /**
-     * Create a new {@link InProcessBundle} for the specified {@link PCollection} with the specified
-     * key.
-     *
-     * <p>See {@link CommittedBundle#getKey()} and {@link CommittedBundle#isKeyed()} for more
-     * information.
-     */
-    public static <T> InProcessBundle<T> keyed(PCollection<T> pcollection, Object key) {
-      return new InProcessBundle<T>(pcollection, true, key);
-    }
-
-    private InProcessBundle(PCollection<T> pcollection, boolean keyed, Object key) {
+    private InProcessBundle(PCollection<T> pcollection, Object key) {
       this.pcollection = pcollection;
-      this.keyed = keyed;
       this.key = key;
       this.elements = ImmutableList.builder();
     }
@@ -117,11 +102,6 @@ class InProcessBundleFactory implements BundleFactory {
         @Nullable
         public Object getKey() {
           return key;
-        }
-
-        @Override
-        public boolean isKeyed() {
-          return keyed;
         }
 
         @Override

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -128,12 +128,6 @@ public class InProcessPipelineRunner
     PCollection<T> getPCollection();
 
     /**
-     * Returns whether this bundle is keyed. A bundle that is part of a {@link PCollection} that
-     * occurs after a {@link GroupByKey} is keyed by the result of the last {@link GroupByKey}.
-     */
-    boolean isKeyed();
-
-    /**
      * Returns the (possibly null) key that was output in the most recent {@link GroupByKey} in the
      * execution of this bundle.
      */

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleFactoryTest.java
@@ -17,7 +17,6 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -72,7 +71,6 @@ public class InProcessBundleFactoryTest {
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
 
-    assertThat(bundle.isKeyed(), is(false));
     assertThat(bundle.getKey(), nullValue());
   }
 
@@ -83,7 +81,6 @@ public class InProcessBundleFactoryTest {
         bundleFactory.createKeyedBundle(null, key, pcollection);
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
-    assertThat(bundle.isKeyed(), is(true));
     assertThat(bundle.getKey(), equalTo(key));
   }
 
@@ -162,7 +159,6 @@ public class InProcessBundleFactoryTest {
         bundleFactory
             .createBundle(bundleFactory.createRootBundle(created).commit(Instant.now()), downstream)
             .commit(Instant.now());
-    assertThat(newBundle.isKeyed(), is(false));
   }
 
   @Test
@@ -173,13 +169,7 @@ public class InProcessBundleFactoryTest {
                 bundleFactory.createKeyedBundle(null, "foo", created).commit(Instant.now()),
                 downstream)
             .commit(Instant.now());
-    assertThat(newBundle.isKeyed(), is(true));
     assertThat(newBundle.getKey(), Matchers.<Object>equalTo("foo"));
-  }
-
-  @Test
-  public void createRootBundleUnkeyed() {
-    assertThat(bundleFactory.createRootBundle(created).commit(Instant.now()).isKeyed(), is(false));
   }
 
   @Test
@@ -189,7 +179,6 @@ public class InProcessBundleFactoryTest {
             .createKeyedBundle(
                 bundleFactory.createRootBundle(created).commit(Instant.now()), "foo", downstream)
             .commit(Instant.now());
-    assertThat(keyedBundle.isKeyed(), is(true));
     assertThat(keyedBundle.getKey(), Matchers.<Object>equalTo("foo"));
   }
 }


### PR DESCRIPTION
The property of keyedness belongs to a PCollection. A BundleFactory
propogates the key as far as possible, but does not track if a bundle is
keyed.

This backports [BEAM #201](https://github.com/apache/incubator-beam/pull/201)