### PR TITLE
Remove redundant close in BoundedReadEvaluatorFactory

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BoundedReadEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BoundedReadEvaluatorFactory.java
@@ -144,7 +144,6 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
                   reader.getCurrent(), reader.getCurrentTimestamp()));
           contentsRemaining = reader.advance();
         }
-        reader.close();
         return StepTransformResult.withHold(transform, BoundedWindow.TIMESTAMP_MAX_VALUE)
             .addOutput(output)
             .build();


### PR DESCRIPTION
The reader is already closed by virtue of being the target of the
try-with-resources block that encompasses all of #finishBundle().

This backports [BEAM #257](https://github.com/apache/incubator-beam/pull/257)