### PR TITLE
Stop cloning coders in the InProcessRunner

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/EncodabilityEnforcementFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/EncodabilityEnforcementFactory.java
@@ -21,7 +21,6 @@ import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.util.CoderUtils;
-import com.google.cloud.dataflow.sdk.util.SerializableUtils;
 import com.google.cloud.dataflow.sdk.util.UserCodeException;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.cloud.dataflow.sdk.values.PCollection;
@@ -45,7 +44,7 @@ class EncodabilityEnforcementFactory implements ModelEnforcementFactory {
     private Coder<T> coder;
 
     public EncodabilityEnforcement(CommittedBundle<T> input) {
-      coder = SerializableUtils.clone(input.getPCollection().getCoder());
+      coder = input.getPCollection().getCoder();
     }
 
     @Override

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactory.java
@@ -26,7 +26,6 @@ import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.util.IllegalMutationException;
 import com.google.cloud.dataflow.sdk.util.MutationDetector;
 import com.google.cloud.dataflow.sdk.util.MutationDetectors;
-import com.google.cloud.dataflow.sdk.util.SerializableUtils;
 import com.google.cloud.dataflow.sdk.util.UserCodeException;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.cloud.dataflow.sdk.values.PCollection;
@@ -84,7 +83,7 @@ class ImmutabilityCheckingBundleFactory implements BundleFactory {
     public ImmutabilityEnforcingBundle(UncommittedBundle<T> underlying) {
       this.underlying = underlying;
       mutationDetectors = HashMultimap.create();
-      coder = SerializableUtils.clone(getPCollection().getCoder());
+      coder = getPCollection().getCoder();
     }
 
     @Override

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityEnforcementFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityEnforcementFactory.java
@@ -22,7 +22,6 @@ import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.util.IllegalMutationException;
 import com.google.cloud.dataflow.sdk.util.MutationDetector;
 import com.google.cloud.dataflow.sdk.util.MutationDetectors;
-import com.google.cloud.dataflow.sdk.util.SerializableUtils;
 import com.google.cloud.dataflow.sdk.util.UserCodeException;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
 
@@ -54,7 +53,7 @@ class ImmutabilityEnforcementFactory implements ModelEnforcementFactory {
     private ImmutabilityCheckingEnforcement(
         CommittedBundle<T> input, AppliedPTransform<?, ?, ?> transform) {
       this.transform = transform;
-      coder = SerializableUtils.clone(input.getPCollection().getCoder());
+      coder = input.getPCollection().getCoder();
       mutationElements = new IdentityHashMap<>();
     }
 


### PR DESCRIPTION
This is excessively slow and also not useful, as coders are required to
be thread-safe

Backports [Beam #261](https://github.com/apache/incubator-beam/pull/261)