### PR TITLE
Return null evaluators from Unavailable Reads

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BoundedReadEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BoundedReadEvaluatorFactory.java
@@ -49,6 +49,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
+  @Nullable
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
       @Nullable CommittedBundle<?> inputBundle,
@@ -60,12 +61,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
   private <OutputT> TransformEvaluator<?> getTransformEvaluator(
       final AppliedPTransform<?, PCollection<OutputT>, Bounded<OutputT>> transform,
       final InProcessEvaluationContext evaluationContext) {
-    BoundedReadEvaluator<?> evaluator =
-        getTransformEvaluatorQueue(transform, evaluationContext).poll();
-    if (evaluator == null) {
-      return EmptyTransformEvaluator.create(transform);
-    }
-    return evaluator;
+    return getTransformEvaluatorQueue(transform, evaluationContext).poll();
   }
 
   /**

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorFactory.java
@@ -30,13 +30,18 @@ public interface TransformEvaluatorFactory {
   /**
    * Create a new {@link TransformEvaluator} for the application of the {@link PTransform}.
    *
-   * Any work that must be done before input elements are processed (such as calling
+   * <p>Any work that must be done before input elements are processed (such as calling
    * {@link DoFn#startBundle(DoFn.Context)}) must be done before the {@link TransformEvaluator} is
    * made available to the caller.
    *
+   * <p>May return null if the application cannot produce an evaluator (for example, it is a
+   * {@link Read} {@link PTransform} where all evaluators are in-use).
+   *
+   * @return An evaluator capable of processing the transform on the bundle, or null if no evaluator
+   * can be constructed.
    * @throws Exception whenever constructing the underlying evaluator throws an exception
    */
-  <InputT> TransformEvaluator<InputT> forApplication(
+  @Nullable <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application, @Nullable CommittedBundle<?> inputBundle,
       InProcessEvaluationContext evaluationContext) throws Exception;
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  * <p>A {@link TransformExecutor} that is currently executing also provides access to the thread
  * that it is being executed on.
  */
-class TransformExecutor<T> implements Callable<InProcessTransformResult> {
+class TransformExecutor<T> implements Runnable {
   public static <T> TransformExecutor<T> create(
       TransformEvaluatorFactory factory,
       Iterable<? extends ModelEnforcementFactory> modelEnforcements,
@@ -92,7 +92,7 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
   }
 
   @Override
-  public InProcessTransformResult call() {
+  public void run() {
     checkState(
         thread.compareAndSet(null, Thread.currentThread()),
         "Tried to execute %s for %s on thread %s, but is already executing on thread %s",
@@ -108,11 +108,14 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
       }
       TransformEvaluator<T> evaluator =
           evaluatorFactory.forApplication(transform, inputBundle, evaluationContext);
+      if (evaluator == null) {
+        // Nothing to do
+        return;
+      }
 
       processElements(evaluator, enforcements);
 
       InProcessTransformResult result = finishBundle(evaluator, enforcements);
-      return result;
     } catch (Throwable t) {
       onComplete.handleThrowable(inputBundle, t);
       if (t instanceof RuntimeException) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadEvaluatorFactory.java
@@ -56,6 +56,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
+  @Nullable
   public <InputT> TransformEvaluator<InputT> forApplication(AppliedPTransform<?, ?, ?> application,
       @Nullable CommittedBundle<?> inputBundle, InProcessEvaluationContext evaluationContext) {
     return getTransformEvaluator((AppliedPTransform) application, evaluationContext);
@@ -64,12 +65,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
   private <OutputT> TransformEvaluator<?> getTransformEvaluator(
       final AppliedPTransform<?, PCollection<OutputT>, Unbounded<OutputT>> transform,
       final InProcessEvaluationContext evaluationContext) {
-    UnboundedReadEvaluator<?> currentEvaluator =
-        getTransformEvaluatorQueue(transform, evaluationContext).poll();
-    if (currentEvaluator == null) {
-      return EmptyTransformEvaluator.create(transform);
-    }
-    return currentEvaluator;
+    return getTransformEvaluatorQueue(transform, evaluationContext).poll();
   }
 
   /**

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/BoundedReadEvaluatorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/BoundedReadEvaluatorFactoryTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -114,15 +115,7 @@ public class BoundedReadEvaluatorFactoryTest {
     when(context.createRootBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null, context);
-    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
-    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
-    assertThat(secondResult.getOutputBundles(), emptyIterable());
-    assertThat(
-        secondOutput.commit(BoundedWindow.TIMESTAMP_MAX_VALUE).getElements(), emptyIterable());
-    assertThat(
-        outputElements,
-        containsInAnyOrder(
-            gw(1L), gw(2L), gw(4L), gw(8L), gw(9L), gw(7L), gw(6L), gw(5L), gw(3L), gw(0L)));
+    assertThat(secondEvaluator, nullValue());
   }
 
   /**
@@ -140,8 +133,7 @@ public class BoundedReadEvaluatorFactoryTest {
         factory.forApplication(longs.getProducingTransformInternal(), null, context);
     TransformEvaluator<?> secondEvaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null, context);
-
-    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
+    assertThat(secondEvaluator, nullValue());
 
     InProcessTransformResult result = evaluator.finishBundle();
     assertThat(result.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
@@ -152,8 +144,6 @@ public class BoundedReadEvaluatorFactoryTest {
         outputElements,
         containsInAnyOrder(
             gw(1L), gw(2L), gw(4L), gw(8L), gw(9L), gw(7L), gw(6L), gw(5L), gw(3L), gw(0L)));
-    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
-    assertThat(secondResult.getOutputBundles(), emptyIterable());
     assertThat(
         secondOutput.commit(BoundedWindow.TIMESTAMP_MAX_VALUE).getElements(), emptyIterable());
     assertThat(

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorServicesTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorServicesTest.java
@@ -65,8 +65,8 @@ public class TransformExecutorServicesTest {
     parallel.schedule(first);
     parallel.schedule(second);
 
-    verify(first).call();
-    verify(second).call();
+    verify(first).run();
+    verify(second).run();
     assertThat(
         scheduled,
         Matchers.allOf(
@@ -93,10 +93,10 @@ public class TransformExecutorServicesTest {
 
     TransformExecutorService serial = TransformExecutorServices.serial(executorService, scheduled);
     serial.schedule(first);
-    verify(first).call();
+    verify(first).run();
 
     serial.schedule(second);
-    verify(second, never()).call();
+    verify(second, never()).run();
 
     assertThat(scheduled, Matchers.<TransformExecutor<?>, Boolean>hasEntry(first, true));
     assertThat(
@@ -106,7 +106,7 @@ public class TransformExecutorServicesTest {
                 Matchers.<TransformExecutor<?>>equalTo(second), any(Boolean.class))));
 
     serial.complete(first);
-    verify(second).call();
+    verify(second).run();
     assertThat(scheduled, Matchers.<TransformExecutor<?>, Boolean>hasEntry(second, true));
     assertThat(
         scheduled,

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
@@ -127,7 +127,7 @@ public class TransformExecutorTest {
             created.getProducingTransformInternal(),
             completionCallback,
             transformEvaluationState);
-    executor.call();
+    executor.run();
 
     assertThat(finishCalled.get(), is(true));
     assertThat(completionCallback.handledResult, equalTo(result));
@@ -346,7 +346,7 @@ public class TransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    executor.call();
+    executor.run();
     TestEnforcement<?> testEnforcement = enforcement.instance;
     assertThat(
         testEnforcement.beforeElements,
@@ -406,7 +406,7 @@ public class TransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    Future<InProcessTransformResult> task = Executors.newSingleThreadExecutor().submit(executor);
+    Future<?> task = Executors.newSingleThreadExecutor().submit(executor);
     testLatch.await();
     fooBytes.getValue()[0] = 'b';
     evaluatorLatch.countDown();
@@ -465,7 +465,7 @@ public class TransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    Future<InProcessTransformResult> task = Executors.newSingleThreadExecutor().submit(executor);
+    Future<?> task = Executors.newSingleThreadExecutor().submit(executor);
     testLatch.await();
     fooBytes.getValue()[0] = 'b';
     evaluatorLatch.countDown();


### PR DESCRIPTION
Null TransformEvaluators for sources represent a source where all splits
are currently in use or completed.

Update TransformExecutor to handle null evaluators properly.

Change TransformExecutor to a Runnable.

Backports [Beam #310](https://github.com/apache/incubator-beam/pull/310)