### PR TITLE
Backport incubator-beam PR #321

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -687,13 +687,13 @@
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcsio</artifactId>
-      <version>1.4.3</version>
+      <version>1.4.5</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>util</artifactId>
-      <version>1.4.3</version>
+      <version>1.4.5</version>
     </dependency>
 
     <dependency>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -459,6 +459,20 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>0.4.0</version>
+      <exclusions>
+        <!-- Exclude an old version of guava that is being pulled in by a transitive
+          dependency of google-api-client -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-protos</artifactId>
       <version>${bigtable.version}</version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -462,6 +462,7 @@
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.4.0</version>
+      <scope>runtime</scope>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled in by a transitive
           dependency of google-api-client -->


### PR DESCRIPTION
https://github.com/apache/incubator-beam/pull/321

Note that maven archetypes already depends on guava 19.0

Also, note that I explicitly bring in google-auth-library-oauth2-http so it matches the incubator-beam version. Normally bigtable client brings in version 0.3.1