### PR TITLE
Reuse DoFns in ParDoEvaluators

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoMultiEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoMultiEvaluatorFactory.java
@@ -24,6 +24,9 @@ import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PCollectionTuple;
 import com.google.cloud.dataflow.sdk.values.TupleTag;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.LoadingCache;
+
 import java.util.Map;
 
 /**
@@ -31,6 +34,13 @@ import java.util.Map;
  * {@link BoundMulti} primitive {@link PTransform}.
  */
 class ParDoMultiEvaluatorFactory implements TransformEvaluatorFactory {
+  private final LoadingCache<DoFn<?, ?>, ThreadLocal<DoFn<?, ?>>> fnClones;
+
+  public ParDoMultiEvaluatorFactory() {
+    fnClones = CacheBuilder.newBuilder()
+        .build(SerializableCloningThreadLocalCacheLoader.<DoFn<?, ?>>create());
+  }
+
   @Override
   public <T> TransformEvaluator<T> forApplication(
       AppliedPTransform<?, ?, ?> application,
@@ -42,21 +52,28 @@ class ParDoMultiEvaluatorFactory implements TransformEvaluatorFactory {
     return evaluator;
   }
 
-  private static <InT, OuT> ParDoInProcessEvaluator<InT> createMultiEvaluator(
+  private <InT, OuT> TransformEvaluator<InT> createMultiEvaluator(
       AppliedPTransform<PCollection<InT>, PCollectionTuple, BoundMulti<InT, OuT>> application,
       CommittedBundle<InT> inputBundle,
       InProcessEvaluationContext evaluationContext) {
     Map<TupleTag<?>, PCollection<?>> outputs = application.getOutput().getAll();
     DoFn<InT, OuT> fn = application.getTransform().getFn();
 
-    return ParDoInProcessEvaluator.create(
-        evaluationContext,
-        inputBundle,
-        application,
-        fn,
-        application.getTransform().getSideInputs(),
-        application.getTransform().getMainOutputTag(),
-        application.getTransform().getSideOutputTags().getAll(),
-        outputs);
+    @SuppressWarnings({"unchecked", "rawtypes"}) ThreadLocal<DoFn<InT, OuT>> fnLocal =
+        (ThreadLocal) fnClones.getUnchecked(application.getTransform().getFn());
+    try {
+      TransformEvaluator<InT> parDoEvaluator = ParDoInProcessEvaluator.create(evaluationContext,
+          inputBundle,
+          application,
+          fnLocal.get(),
+          application.getTransform().getSideInputs(),
+          application.getTransform().getMainOutputTag(),
+          application.getTransform().getSideOutputTags().getAll(),
+          outputs);
+      return ThreadLocalInvalidatingTransformEvaluator.wrapping(parDoEvaluator, fnLocal);
+    } catch (Exception e) {
+      fnLocal.remove();
+      throw e;
+    }
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoSingleEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoSingleEvaluatorFactory.java
@@ -17,10 +17,13 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.transforms.ParDo.Bound;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.TupleTag;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Collections;
@@ -30,6 +33,13 @@ import java.util.Collections;
  * {@link Bound ParDo.Bound} primitive {@link PTransform}.
  */
 class ParDoSingleEvaluatorFactory implements TransformEvaluatorFactory {
+  private final LoadingCache<DoFn<?, ?>, ThreadLocal<DoFn<?, ?>>> fnClones;
+
+  public ParDoSingleEvaluatorFactory() {
+    fnClones = CacheBuilder.newBuilder()
+        .build(SerializableCloningThreadLocalCacheLoader.<DoFn<?, ?>>create());
+  }
+
   @Override
   public <T> TransformEvaluator<T> forApplication(
       final AppliedPTransform<?, ?, ?> application,
@@ -41,20 +51,28 @@ class ParDoSingleEvaluatorFactory implements TransformEvaluatorFactory {
     return evaluator;
   }
 
-  private static <InputT, OutputT> ParDoInProcessEvaluator<InputT> createSingleEvaluator(
+  private <InputT, OutputT> TransformEvaluator<InputT> createSingleEvaluator(
       @SuppressWarnings("rawtypes") AppliedPTransform<PCollection<InputT>, PCollection<OutputT>,
           Bound<InputT, OutputT>> application,
       CommittedBundle<InputT> inputBundle, InProcessEvaluationContext evaluationContext) {
     TupleTag<OutputT> mainOutputTag = new TupleTag<>("out");
 
-    return ParDoInProcessEvaluator.create(
-        evaluationContext,
-        inputBundle,
-        application,
-        application.getTransform().getFn(),
-        application.getTransform().getSideInputs(),
-        mainOutputTag,
-        Collections.<TupleTag<?>>emptyList(),
-        ImmutableMap.<TupleTag<?>, PCollection<?>>of(mainOutputTag, application.getOutput()));
+    @SuppressWarnings({"unchecked", "rawtypes"}) ThreadLocal<DoFn<InputT, OutputT>> fnLocal =
+        (ThreadLocal) fnClones.getUnchecked(application.getTransform().getFn());
+    try {
+      ParDoInProcessEvaluator<InputT> parDoEvaluator = ParDoInProcessEvaluator.create(
+          evaluationContext,
+          inputBundle,
+          application,
+          fnLocal.get(),
+          application.getTransform().getSideInputs(),
+          mainOutputTag,
+          Collections.<TupleTag<?>>emptyList(),
+          ImmutableMap.<TupleTag<?>, PCollection<?>>of(mainOutputTag, application.getOutput()));
+      return ThreadLocalInvalidatingTransformEvaluator.wrapping(parDoEvaluator, fnLocal);
+    } catch (Exception e) {
+      fnLocal.remove();
+      throw e;
+    }
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/SerializableCloningThreadLocalCacheLoader.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/SerializableCloningThreadLocalCacheLoader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.util.SerializableUtils;
+import com.google.common.cache.CacheLoader;
+
+import java.io.Serializable;
+
+/**
+ * A {@link CacheLoader} that loads {@link ThreadLocal ThreadLocals} with initial values equal to
+ * the clone of the key.
+ */
+class SerializableCloningThreadLocalCacheLoader<T extends Serializable>
+    extends CacheLoader<T, ThreadLocal<T>> {
+  public static <T extends Serializable> CacheLoader<T, ThreadLocal<T>> create() {
+    return new SerializableCloningThreadLocalCacheLoader<T>();
+  }
+
+  @Override
+  public ThreadLocal<T> load(T key) throws Exception {
+    return new CloningThreadLocal<>(key);
+  }
+
+  private static class CloningThreadLocal<T extends Serializable> extends ThreadLocal<T> {
+    private final T original;
+
+    public CloningThreadLocal(T value) {
+      this.original = value;
+    }
+
+    @Override
+    public T initialValue() {
+      return SerializableUtils.clone(original);
+    }
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/SerializableCloningThreadLocalCacheLoaderTest.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/SerializableCloningThreadLocalCacheLoaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsSame.theInstance;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+
+/**
+ * Tests for {@link SerializableCloningThreadLocalCacheLoader}.
+ */
+@RunWith(JUnit4.class)
+public class SerializableCloningThreadLocalCacheLoaderTest {
+  private SerializableCloningThreadLocalCacheLoader<Record> loader;
+
+  @Before
+  public void setup() {
+    loader = new SerializableCloningThreadLocalCacheLoader();
+  }
+
+  @Test
+  public void returnsCopiesOfOriginal() throws Exception {
+    Record original = new Record();
+    ThreadLocal<Record> loaded = loader.load(original);
+    assertThat(loaded.get(), not(nullValue()));
+    assertThat(loaded.get(), equalTo(original));
+    assertThat(loaded.get(), not(theInstance(original)));
+  }
+
+  @Test
+  public void returnsDifferentCopiesInDifferentThreads() throws Exception {
+    Record original = new Record();
+    final ThreadLocal<Record> loaded = loader.load(original);
+    assertThat(loaded.get(), not(nullValue()));
+    assertThat(loaded.get(), equalTo(original));
+    assertThat(loaded.get(), not(theInstance(original)));
+
+    Callable<Record> otherThread = new Callable<Record>() {
+      @Override
+      public Record call() throws Exception {
+        return loaded.get();
+      }
+    };
+    Record sameThread = loaded.get();
+    Record firstOtherThread = Executors.newSingleThreadExecutor().submit(otherThread).get();
+    Record secondOtherThread = Executors.newSingleThreadExecutor().submit(otherThread).get();
+
+    assertThat(sameThread, equalTo(firstOtherThread));
+    assertThat(sameThread, equalTo(secondOtherThread));
+    assertThat(sameThread, not(theInstance(firstOtherThread)));
+    assertThat(sameThread, not(theInstance(secondOtherThread)));
+    assertThat(firstOtherThread, not(theInstance(secondOtherThread)));
+  }
+
+  private static class Record implements Serializable {
+    private final double rand = Math.random();
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof Record)) {
+        return false;
+      }
+      Record that = (Record) other;
+      return this.rand == that.rand;
+    }
+
+    @Override
+    public int hashCode() {
+      return 1;
+    }
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ThreadLocalInvalidatingTransformEvaluator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ThreadLocalInvalidatingTransformEvaluator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+
+/**
+ * A {@link TransformEvaluator} which delegates calls to an underlying {@link TransformEvaluator},
+ * clearing the value of a {@link ThreadLocal} if any call throws an exception.
+ */
+class ThreadLocalInvalidatingTransformEvaluator<InputT>
+    implements TransformEvaluator<InputT> {
+  private final TransformEvaluator<InputT> underlying;
+  private final ThreadLocal<?> threadLocal;
+
+  public static <InputT> TransformEvaluator<InputT> wrapping(
+      TransformEvaluator<InputT> underlying,
+      ThreadLocal<?> threadLocal) {
+    return new ThreadLocalInvalidatingTransformEvaluator<>(underlying, threadLocal);
+  }
+
+  private ThreadLocalInvalidatingTransformEvaluator(
+      TransformEvaluator<InputT> underlying, ThreadLocal<?> threadLocal) {
+    this.underlying = underlying;
+    this.threadLocal = threadLocal;
+  }
+
+  @Override
+  public void processElement(WindowedValue<InputT> element) throws Exception {
+    try {
+      underlying.processElement(element);
+    } catch (Exception e) {
+      threadLocal.remove();
+      throw e;
+    }
+  }
+
+  @Override
+  public InProcessTransformResult finishBundle() throws Exception {
+    try {
+      return underlying.finishBundle();
+    } catch (Exception e) {
+      threadLocal.remove();
+      throw e;
+    }
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ThreadLocalInvalidatingTransformEvaluatorTest.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ThreadLocalInvalidatingTransformEvaluatorTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for {@link ThreadLocalInvalidatingTransformEvaluator}.
+ */
+@RunWith(JUnit4.class)
+public class ThreadLocalInvalidatingTransformEvaluatorTest {
+  private ThreadLocal<Object> threadLocal;
+
+  @Before
+  public void setup() {
+    threadLocal = new ThreadLocal<>();
+    threadLocal.set(new Object());
+  }
+
+  @Test
+  public void delegatesToUnderlying() throws Exception {
+    RecordingTransformEvaluator underlying = new RecordingTransformEvaluator();
+    Object original = threadLocal.get();
+    TransformEvaluator<Object> evaluator =
+        ThreadLocalInvalidatingTransformEvaluator.wrapping(underlying, threadLocal);
+    WindowedValue<Object> first = WindowedValue.valueInGlobalWindow(new Object());
+    WindowedValue<Object> second = WindowedValue.valueInGlobalWindow(new Object());
+    evaluator.processElement(first);
+    assertThat(underlying.objects, containsInAnyOrder(first));
+    evaluator.processElement(second);
+    evaluator.finishBundle();
+
+    assertThat(underlying.finishBundleCalled, is(true));
+    assertThat(underlying.objects, containsInAnyOrder(second, first));
+  }
+
+  @Test
+  public void removesOnExceptionInProcessElement() {
+    ThrowingTransformEvaluator underlying = new ThrowingTransformEvaluator();
+    Object original = threadLocal.get();
+    assertThat(original, not(nullValue()));
+    TransformEvaluator<Object> evaluator =
+        ThreadLocalInvalidatingTransformEvaluator.wrapping(underlying, threadLocal);
+
+    try {
+      evaluator.processElement(WindowedValue.valueInGlobalWindow(new Object()));
+    } catch (Exception e) {
+      assertThat(threadLocal.get(), nullValue());
+      return;
+    }
+    fail("Expected ThrowingTransformEvaluator to throw on method call");
+  }
+
+  @Test
+  public void removesOnExceptionInFinishBundle() {
+    ThrowingTransformEvaluator underlying = new ThrowingTransformEvaluator();
+    Object original = threadLocal.get();
+    // the ThreadLocal is set when the evaluator starts
+    assertThat(original, not(nullValue()));
+    TransformEvaluator<Object> evaluator =
+        ThreadLocalInvalidatingTransformEvaluator.wrapping(underlying, threadLocal);
+
+    try {
+      evaluator.finishBundle();
+    } catch (Exception e) {
+      assertThat(threadLocal.get(), nullValue());
+      return;
+    }
+    fail("Expected ThrowingTransformEvaluator to throw on method call");
+  }
+
+  private class RecordingTransformEvaluator implements TransformEvaluator<Object> {
+    private boolean finishBundleCalled;
+    private List<WindowedValue<Object>> objects;
+
+    public RecordingTransformEvaluator() {
+      this.finishBundleCalled = true;
+      this.objects = new ArrayList<>();
+    }
+
+    @Override
+    public void processElement(WindowedValue<Object> element) throws Exception {
+      objects.add(element);
+    }
+
+    @Override
+    public InProcessTransformResult finishBundle() throws Exception {
+      finishBundleCalled = true;
+      return null;
+    }
+  }
+
+  private class ThrowingTransformEvaluator implements TransformEvaluator<Object> {
+    @Override
+    public void processElement(WindowedValue<Object> element) throws Exception {
+      throw new Exception();
+    }
+
+    @Override
+    public InProcessTransformResult finishBundle() throws Exception {
+      throw new Exception();
+    }
+  }
+}


### PR DESCRIPTION
This allows the runner to avoid cloning DoFns for every input bundle.

Backports [Beam #320](https://github.com/apache/incubator-beam/pull/320)