### PR TITLE
Enforce non-null preconditions

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
@@ -61,6 +61,7 @@ public interface InProcessTransformResult {
    *
    * If this evaluation did not access state, this may return null.
    */
+  @Nullable
   CopyOnAccessInMemoryStateInternals<?> getState();
 
   /**
@@ -71,5 +72,4 @@ public interface InProcessTransformResult {
    * <p>If this evaluation did not add or remove any timers, returns an empty TimerUpdate.
    */
   TimerUpdate getTimerUpdate();
-
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepTransformResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepTransformResult.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
@@ -28,15 +30,17 @@ import org.joda.time.Instant;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 /**
  * An immutable {@link InProcessTransformResult}.
  */
 public class StepTransformResult implements InProcessTransformResult {
   private final AppliedPTransform<?, ?, ?> transform;
   private final Iterable<? extends UncommittedBundle<?>> bundles;
-  private final CopyOnAccessInMemoryStateInternals<?> state;
+  @Nullable private final CopyOnAccessInMemoryStateInternals<?> state;
   private final TimerUpdate timerUpdate;
-  private final CounterSet counters;
+  @Nullable private final CounterSet counters;
   private final Instant watermarkHold;
 
   private StepTransformResult(
@@ -46,12 +50,12 @@ public class StepTransformResult implements InProcessTransformResult {
       TimerUpdate timerUpdate,
       CounterSet counters,
       Instant watermarkHold) {
-    this.transform = transform;
-    this.bundles = outputBundles;
+    this.transform = checkNotNull(transform);
+    this.bundles = checkNotNull(outputBundles);
     this.state = state;
-    this.timerUpdate = timerUpdate;
+    this.timerUpdate = checkNotNull(timerUpdate);
     this.counters = counters;
-    this.watermarkHold = watermarkHold;
+    this.watermarkHold = checkNotNull(watermarkHold);
   }
 
   @Override
@@ -74,6 +78,7 @@ public class StepTransformResult implements InProcessTransformResult {
     return watermarkHold;
   }
 
+  @Nullable
   @Override
   public CopyOnAccessInMemoryStateInternals<?> getState() {
     return state;


### PR DESCRIPTION
The InProcessPipelineRunner expects some result values to be non-null.
Enforce those early.

Backports [Beam #153](https://github.com/apache/incubator-beam/pull/153)