### PR TITLE
Backport: Evaluate display data from InProcessPipelineRunner

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandler.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandler.java
@@ -84,7 +84,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * {@link PipelineOptions#as(Class)}.
  */
 @ThreadSafe
-class ProxyInvocationHandler implements InvocationHandler {
+class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   /**
    * No two instances of this class are considered equivalent hence we generate a random hash code
@@ -141,7 +141,8 @@ class ProxyInvocationHandler implements InvocationHandler {
         && args[0] instanceof DisplayData.Builder) {
       @SuppressWarnings("unchecked")
       DisplayData.Builder builder = (DisplayData.Builder) args[0];
-      populateDisplayData(builder);
+      // Explicitly set display data namespace so thrown exceptions will have sensible type.
+      builder.include(this, PipelineOptions.class);
       return Void.TYPE;
     }
     String methodName = method.getName();
@@ -302,7 +303,7 @@ class ProxyInvocationHandler implements InvocationHandler {
    * Populate display data. See {@link HasDisplayData#populateDisplayData}. All explicitly set
    * pipeline options will be added as display data.
    */
-  private void populateDisplayData(DisplayData.Builder builder) {
+  public void populateDisplayData(DisplayData.Builder builder) {
     Set<PipelineOptionSpec> optionSpecs = PipelineOptionsReflector.getOptionSpecs(knownInterfaces);
     Multimap<String, PipelineOptionSpec> optionsMap = buildOptionNameToSpecMap(optionSpecs);
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/DisplayDataValidator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/DisplayDataValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.runners.TransformTreeNode;
+import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
+import com.google.cloud.dataflow.sdk.transforms.display.HasDisplayData;
+import com.google.cloud.dataflow.sdk.values.PValue;
+
+/**
+ * Validate correct implementation of {@link DisplayData} by evaluating
+ * {@link HasDisplayData#populateDisplayData(DisplayData.Builder)} during pipeline construction.
+ */
+class DisplayDataValidator {
+  // Do not instantiate
+  private DisplayDataValidator() {}
+
+  static void validatePipeline(Pipeline pipeline) {
+    validateOptions(pipeline);
+    validateTransforms(pipeline);
+  }
+
+  private static void validateOptions(Pipeline pipeline) {
+    evaluateDisplayData(pipeline.getOptions());
+  }
+
+  private static void validateTransforms(Pipeline pipeline) {
+    pipeline.traverseTopologically(Visitor.INSTANCE);
+  }
+
+  private static void evaluateDisplayData(HasDisplayData component) {
+    DisplayData.from(component);
+  }
+
+  private static class Visitor implements Pipeline.PipelineVisitor {
+    private static final Visitor INSTANCE = new Visitor();
+
+    @Override
+    public void enterCompositeTransform(TransformTreeNode node) {
+      if (!node.isRootNode()) {
+        evaluateDisplayData(node.getTransform());
+      }
+    }
+
+    @Override
+    public void visitTransform(TransformTreeNode node) {
+      evaluateDisplayData(node.getTransform());
+    }
+
+    @Override
+    public void leaveCompositeTransform(TransformTreeNode node) {}
+
+    @Override
+    public void visitValue(PValue value, TransformTreeNode producer) {}
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -223,6 +223,8 @@ public class InProcessPipelineRunner
                 GroupByKey.class, InProcessGroupByKeyOnly.class));
     pipeline.traverseTopologically(keyedPValueVisitor);
 
+    DisplayDataValidator.validatePipeline(pipeline);
+
     InProcessEvaluationContext context =
         InProcessEvaluationContext.create(
             getPipelineOptions(),

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayData.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayData.java
@@ -654,16 +654,28 @@ public class DisplayData implements Serializable {
 
         try {
           subComponent.populateDisplayData(this);
+        } catch (PopulateDisplayDataException e) {
+          // Don't re-wrap exceptions recursively.
+          throw e;
         } catch (Throwable e) {
           String msg = String.format("Error while populating display data for component: %s",
               namespace);
-          throw new RuntimeException(msg, e);
+          throw new PopulateDisplayDataException(msg, e);
         }
 
         this.latestNs = prevNs;
       }
 
       return this;
+    }
+
+    /**
+     * Marker exception class for exceptions encountered while populating display data.
+     */
+    private class PopulateDisplayDataException extends RuntimeException {
+      PopulateDisplayDataException(String message, Throwable cause) {
+        super(message, cause);
+      }
     }
 
     @Override

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunnerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunnerTest.java
@@ -123,6 +123,7 @@ public class InProcessPipelineRunnerTest implements Serializable {
     p.run();
   }
 
+  /** {@link PipelineOptions} to inject broken object type. */
   public interface ObjectPipelineOptions extends PipelineOptions {
     Object getValue();
     void setValue(Object value);

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunnerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunnerTest.java
@@ -123,7 +123,7 @@ public class InProcessPipelineRunnerTest implements Serializable {
     p.run();
   }
 
-  interface ObjectPipelineOptions extends PipelineOptions {
+  public interface ObjectPipelineOptions extends PipelineOptions {
     Object getValue();
     void setValue(Object value);
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunnerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunnerTest.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
+import static org.hamcrest.Matchers.is;
+
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
@@ -22,12 +24,19 @@ import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.I
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
 import com.google.cloud.dataflow.sdk.transforms.Count;
 import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.transforms.MapElements;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.transforms.SimpleFunction;
+import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -38,6 +47,8 @@ import java.io.Serializable;
  */
 @RunWith(JUnit4.class)
 public class InProcessPipelineRunnerTest implements Serializable {
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void wordCountShouldSucceed() throws Throwable {
     Pipeline p = getPipeline();
@@ -65,6 +76,58 @@ public class InProcessPipelineRunnerTest implements Serializable {
     InProcessPipelineResult result = ((InProcessPipelineResult) p.run());
     result.awaitCompletion();
   }
+
+  @Test
+  public void transformDisplayDataExceptionShouldFail() {
+    DoFn<Integer, Integer> brokenDoFn = new DoFn<Integer, Integer>() {
+      @Override
+      public void processElement(ProcessContext c) throws Exception {}
+
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        throw new RuntimeException("oh noes!");
+      }
+    };
+
+    Pipeline p = getPipeline();
+    p
+        .apply(Create.of(1, 2, 3))
+        .apply(ParDo.of(brokenDoFn));
+
+    thrown.expectMessage(brokenDoFn.getClass().getName());
+    thrown.expectCause(ThrowableMessageMatcher.hasMessage(is("oh noes!")));
+    p.run();
+  }
+
+  @Test
+  public void pipelineOptionsDisplayDataExceptionShouldFail() {
+    Object brokenValueType = new Object() {
+      @JsonValue
+      public int getValue () {
+        return 42;
+      }
+
+      @Override
+      public String toString() {
+        throw new RuntimeException("oh noes!!");
+      }
+    };
+
+    Pipeline p = getPipeline();
+    p.getOptions().as(ObjectPipelineOptions.class).setValue(brokenValueType);
+
+    p.apply(Create.of(1, 2, 3));
+
+    thrown.expectMessage(PipelineOptions.class.getName());
+    thrown.expectCause(ThrowableMessageMatcher.hasMessage(is("oh noes!!")));
+    p.run();
+  }
+
+  interface ObjectPipelineOptions extends PipelineOptions {
+    Object getValue();
+    void setValue(Object value);
+  }
+
 
   private Pipeline getPipeline() {
     PipelineOptions opts = PipelineOptionsFactory.create();

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayDataTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayDataTest.java
@@ -1023,6 +1023,25 @@ public class DisplayDataTest implements Serializable {
     DisplayData.from(component);
   }
 
+  @Test
+  public void testExceptionsNotWrappedRecursively() {
+    final RuntimeException cause = new RuntimeException("oh noes!");
+    HasDisplayData component = new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.include(new HasDisplayData() {
+          @Override
+          public void populateDisplayData(Builder builder) {
+            throw cause;
+          }
+        });
+      }
+    };
+
+    thrown.expectCause(is(cause));
+    DisplayData.from(component);
+  }
+
   private static class IdentityTransform<T> extends PTransform<PCollection<T>, PCollection<T>> {
     @Override
     public PCollection<T> apply(PCollection<T> input) {


### PR DESCRIPTION
Display data can be added to any PTransform to be used
for display from any runner. Runners are not required to
consume display data, and currently many don't.

This changes InProcessRunner to consumer display data (and then
discard it) in order to validate that display data is properly
implemented on transforms within a pipeline. Exceptions thrown
within HasDisplayData implementations will cause Pipeline.run()
to fail.

(cherry picked from commit ac98c4a01f7e4b2bba3e99271b66e141e7555de8)