### PR TITLE
Use Structural Value keys instead of User Values

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BundleFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BundleFactory.java
@@ -42,7 +42,7 @@ public interface BundleFactory {
    * {@link InProcessGroupByKeyOnly} {@link PTransform PTransforms}. Elements added to the bundle
    * belong to the {@code output} {@link PCollection}.
    */
-  public <T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, Object key, PCollection<T> output);
+  public <K, T> UncommittedBundle<T> createKeyedBundle(
+      CommittedBundle<?> input, StructuralKey<K> key, PCollection<T> output);
 }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
@@ -393,17 +393,19 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
     private boolean fireTimers() throws Exception {
       try {
         boolean firedTimers = false;
-        for (Map.Entry<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> transformTimers :
+        for (Map.Entry<
+               AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> transformTimers :
             evaluationContext.extractFiredTimers().entrySet()) {
           AppliedPTransform<?, ?, ?> transform = transformTimers.getKey();
-          for (Map.Entry<Object, FiredTimers> keyTimers : transformTimers.getValue().entrySet()) {
+          for (Map.Entry<StructuralKey<?>, FiredTimers> keyTimers :
+              transformTimers.getValue().entrySet()) {
             for (TimeDomain domain : TimeDomain.values()) {
               Collection<TimerData> delivery = keyTimers.getValue().getTimers(domain);
               if (delivery.isEmpty()) {
                 continue;
               }
               KeyedWorkItem<Object, Object> work =
-                  KeyedWorkItems.timersWorkItem(keyTimers.getKey(), delivery);
+                  KeyedWorkItems.timersWorkItem(keyTimers.getKey().getKey(), delivery);
               @SuppressWarnings({"unchecked", "rawtypes"})
               CommittedBundle<?> bundle =
                   evaluationContext

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/GroupByKeyEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/GroupByKeyEvaluatorFactory.java
@@ -145,8 +145,10 @@ class GroupByKeyEvaluatorFactory implements TransformEvaluatorFactory {
         K key = groupedEntry.getKey().key;
         KeyedWorkItem<K, V> groupedKv =
             KeyedWorkItems.elementsWorkItem(key, groupedEntry.getValue());
-        UncommittedBundle<KeyedWorkItem<K, V>> bundle =
-            evaluationContext.createKeyedBundle(inputBundle, key, application.getOutput());
+        UncommittedBundle<KeyedWorkItem<K, V>> bundle = evaluationContext.createKeyedBundle(
+            inputBundle,
+            StructuralKey.of(key, keyCoder),
+            application.getOutput());
         bundle.add(WindowedValue.valueInGlobalWindow(groupedKv));
         resultBuilder.addOutput(bundle);
       }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactory.java
@@ -46,7 +46,7 @@ import org.joda.time.Instant;
 class ImmutabilityCheckingBundleFactory implements BundleFactory {
   /**
    * Create a new {@link ImmutabilityCheckingBundleFactory} that uses the underlying
-   * {@link BundleFactory} create of the output bundle.
+   * {@link BundleFactory} to create the output bundle.
    */
   public static ImmutabilityCheckingBundleFactory create(BundleFactory underlying) {
     return new ImmutabilityCheckingBundleFactory(underlying);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactory.java
@@ -46,7 +46,7 @@ import org.joda.time.Instant;
 class ImmutabilityCheckingBundleFactory implements BundleFactory {
   /**
    * Create a new {@link ImmutabilityCheckingBundleFactory} that uses the underlying
-   * {@link BundleFactory} to create the output bundle.
+   * {@link BundleFactory} create of the output bundle.
    */
   public static ImmutabilityCheckingBundleFactory create(BundleFactory underlying) {
     return new ImmutabilityCheckingBundleFactory(underlying);
@@ -69,8 +69,8 @@ class ImmutabilityCheckingBundleFactory implements BundleFactory {
   }
 
   @Override
-  public <T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, Object key, PCollection<T> output) {
+  public <K, T> UncommittedBundle<T> createKeyedBundle(
+      CommittedBundle<?> input, StructuralKey<K> key, PCollection<T> output) {
     return new ImmutabilityEnforcingBundle<>(underlying.createKeyedBundle(input, key, output));
   }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -75,7 +75,7 @@ class InProcessEvaluationContext {
   /** The step name for each {@link AppliedPTransform} in the {@link Pipeline}. */
   private final Map<AppliedPTransform<?, ?, ?>, String> stepNames;
 
-  /** The options that were used create of this {@link Pipeline}. */
+  /** The options that were used to create this {@link Pipeline}. */
   private final InProcessPipelineOptions options;
 
   private final BundleFactory bundleFactory;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -75,7 +75,7 @@ class InProcessEvaluationContext {
   /** The step name for each {@link AppliedPTransform} in the {@link Pipeline}. */
   private final Map<AppliedPTransform<?, ?, ?>, String> stepNames;
 
-  /** The options that were used to create this {@link Pipeline}. */
+  /** The options that were used create of this {@link Pipeline}. */
   private final InProcessPipelineOptions options;
 
   private final BundleFactory bundleFactory;
@@ -230,8 +230,8 @@ class InProcessEvaluationContext {
    * Create a {@link UncommittedBundle} with the specified keys at the specified step. For use by
    * {@link InProcessGroupByKeyOnly} {@link PTransform PTransforms}.
    */
-  public <T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, Object key, PCollection<T> output) {
+  public <K, T> UncommittedBundle<T> createKeyedBundle(
+      CommittedBundle<?> input, StructuralKey<K> key, PCollection<T> output) {
     return bundleFactory.createKeyedBundle(input, key, output);
   }
 
@@ -299,7 +299,7 @@ class InProcessEvaluationContext {
    * Get an {@link ExecutionContext} for the provided {@link AppliedPTransform} and key.
    */
   public InProcessExecutionContext getExecutionContext(
-      AppliedPTransform<?, ?, ?> application, Object key) {
+      AppliedPTransform<?, ?, ?> application, StructuralKey<?> key) {
     StepAndKey stepAndKey = StepAndKey.of(application, key);
     return new InProcessExecutionContext(
         options.getClock(),
@@ -368,9 +368,9 @@ class InProcessEvaluationContext {
    * <p>This is a destructive operation. Timers will only appear in the result of this method once
    * for each time they are set.
    */
-  public Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> extractFiredTimers() {
+  public Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> extractFiredTimers() {
     forceRefresh();
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> fired =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> fired =
         watermarkManager.extractFiredTimers();
     return fired;
   }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessExecutionContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessExecutionContext.java
@@ -32,11 +32,11 @@ import com.google.cloud.dataflow.sdk.util.state.CopyOnAccessInMemoryStateInterna
 class InProcessExecutionContext
     extends BaseExecutionContext<InProcessExecutionContext.InProcessStepContext> {
   private final Clock clock;
-  private final Object key;
+  private final StructuralKey<?> key;
   private final CopyOnAccessInMemoryStateInternals<Object> existingState;
   private final TransformWatermarks watermarks;
 
-  public InProcessExecutionContext(Clock clock, Object key,
+  public InProcessExecutionContext(Clock clock, StructuralKey<?> key,
       CopyOnAccessInMemoryStateInternals<Object> existingState, TransformWatermarks watermarks) {
     this.clock = clock;
     this.key = key;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -60,8 +60,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import javax.annotation.Nullable;
-
 /**
  * An In-Memory implementation of the Dataflow Programming Model. Supports Unbounded
  * {@link PCollection PCollections}.
@@ -131,11 +129,10 @@ public class InProcessPipelineRunner
     PCollection<T> getPCollection();
 
     /**
-     * Returns the (possibly null) key that was output in the most recent {@link GroupByKey} in the
+     * Returns the key that was output in the most recent {@link GroupByKey} in the
      * execution of this bundle.
      */
-    @Nullable
-    Object getKey();
+    StructuralKey<?> getKey();
 
     /**
      * Returns an {@link Iterable} containing all of the elements that have been added to this

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepAndKey.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepAndKey.java
@@ -26,16 +26,16 @@ import java.util.Objects;
  */
 final class StepAndKey {
   private final AppliedPTransform<?, ?, ?> step;
-  private final Object key;
+  private final StructuralKey<?> key;
 
   /**
    * Create a new {@link StepAndKey} with the provided step and key.
    */
-  public static StepAndKey of(AppliedPTransform<?, ?, ?> step, Object key) {
+  public static StepAndKey of(AppliedPTransform<?, ?, ?> step, StructuralKey<?> key) {
     return new StepAndKey(step, key);
   }
 
-  private StepAndKey(AppliedPTransform<?, ?, ?> step, Object key) {
+  private StepAndKey(AppliedPTransform<?, ?, ?> step, StructuralKey<?> key) {
     this.step = step;
     this.key = key;
   }
@@ -44,7 +44,7 @@ final class StepAndKey {
   public String toString() {
     return MoreObjects.toStringHelper(StepAndKey.class)
         .add("step", step.getFullName())
-        .add("key", key)
+        .add("key", key.getKey())
         .toString();
   }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StructuralKey.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StructuralKey.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+import com.google.cloud.dataflow.sdk.util.CoderUtils;
+
+/**
+ * A (Key, Coder) pair that uses the structural value of the key (as provided by
+ * {@link Coder#structuralValue(Object)}) to perform equality and hashing.
+ */
+class StructuralKey<K> {
+  /**
+   * Create a new Structural Key of the provided key that can be encoded by the provided coder.
+   */
+  public static <K> StructuralKey<K> of(K key, Coder<K> coder) {
+    try {
+      return new StructuralKey<>(coder, key);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Could not encode a key with its provided coder " + coder.getClass().getSimpleName(), e);
+    }
+  }
+
+  private final Coder<K> coder;
+  private final Object structuralValue;
+  private final byte[] encoded;
+
+  private StructuralKey(Coder<K> coder, K key) throws Exception {
+    this.coder = coder;
+    this.structuralValue = coder.structuralValue(key);
+    this.encoded = CoderUtils.encodeToByteArray(coder, key);
+  }
+
+  public K getKey() {
+    try {
+      return CoderUtils.decodeFromByteArray(coder, encoded);
+    } catch (CoderException e) {
+      throw new IllegalArgumentException(
+          "Could not decode Key with coder of type " + coder.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (other instanceof StructuralKey) {
+      StructuralKey that = (StructuralKey) other;
+      return structuralValue.equals(that.structuralValue);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return structuralValue.hashCode();
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/GroupByKeyEvaluatorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/GroupByKeyEvaluatorFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
@@ -69,17 +70,27 @@ public class GroupByKeyEvaluatorFactoryTest {
     CommittedBundle<KV<String, WindowedValue<Integer>>> inputBundle =
         bundleFactory.createRootBundle(kvs).commit(Instant.now());
     InProcessEvaluationContext evaluationContext = mock(InProcessEvaluationContext.class);
-
+    StructuralKey<String> fooKey = StructuralKey.of("foo", StringUtf8Coder.of());
     UncommittedBundle<KeyedWorkItem<String, Integer>> fooBundle =
-        bundleFactory.createKeyedBundle(null, "foo", groupedKvs);
-    UncommittedBundle<KeyedWorkItem<String, Integer>> barBundle =
-        bundleFactory.createKeyedBundle(null, "bar", groupedKvs);
-    UncommittedBundle<KeyedWorkItem<String, Integer>> bazBundle =
-        bundleFactory.createKeyedBundle(null, "baz", groupedKvs);
+        bundleFactory.createKeyedBundle(null, fooKey, groupedKvs);
 
-    when(evaluationContext.createKeyedBundle(inputBundle, "foo", groupedKvs)).thenReturn(fooBundle);
-    when(evaluationContext.createKeyedBundle(inputBundle, "bar", groupedKvs)).thenReturn(barBundle);
-    when(evaluationContext.createKeyedBundle(inputBundle, "baz", groupedKvs)).thenReturn(bazBundle);
+    StructuralKey<String> barKey = StructuralKey.of("bar", StringUtf8Coder.of());
+    UncommittedBundle<KeyedWorkItem<String, Integer>> barBundle =
+        bundleFactory.createKeyedBundle(null, barKey, groupedKvs);
+
+    StructuralKey<String> bazKey = StructuralKey.of("baz", StringUtf8Coder.of());
+    UncommittedBundle<KeyedWorkItem<String, Integer>> bazBundle =
+        bundleFactory.createKeyedBundle(null, bazKey, groupedKvs);
+
+    when(evaluationContext.createKeyedBundle(inputBundle,
+        fooKey,
+        groupedKvs)).thenReturn(fooBundle);
+    when(evaluationContext.createKeyedBundle(inputBundle,
+        barKey,
+        groupedKvs)).thenReturn(barBundle);
+    when(evaluationContext.createKeyedBundle(inputBundle,
+        bazKey,
+        groupedKvs)).thenReturn(bazBundle);
 
     // The input to a GroupByKey is assumed to be a KvCoder
     @SuppressWarnings("unchecked")

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ImmutabilityCheckingBundleFactoryTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
 
 import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
@@ -73,7 +74,9 @@ public class ImmutabilityCheckingBundleFactoryTest {
   @Test
   public void noMutationKeyedBundleSucceeds() {
     CommittedBundle<byte[]> root = factory.createRootBundle(created).commit(Instant.now());
-    UncommittedBundle<byte[]> keyed = factory.createKeyedBundle(root, "mykey", transformed);
+    UncommittedBundle<byte[]> keyed = factory.createKeyedBundle(root,
+        StructuralKey.of("mykey", StringUtf8Coder.of()),
+        transformed);
 
     WindowedValue<byte[]> windowedArray =
         WindowedValue.of(
@@ -119,7 +122,9 @@ public class ImmutabilityCheckingBundleFactoryTest {
   @Test
   public void mutationBeforeAddKeyedBundleSucceeds() {
     CommittedBundle<byte[]> root = factory.createRootBundle(created).commit(Instant.now());
-    UncommittedBundle<byte[]> keyed = factory.createKeyedBundle(root, "mykey", transformed);
+    UncommittedBundle<byte[]> keyed = factory.createKeyedBundle(root,
+        StructuralKey.of("mykey", StringUtf8Coder.of()),
+        transformed);
 
     byte[] array = new byte[] {4, 8, 12};
     array[0] = Byte.MAX_VALUE;
@@ -170,7 +175,9 @@ public class ImmutabilityCheckingBundleFactoryTest {
   @Test
   public void mutationAfterAddKeyedBundleThrows() {
     CommittedBundle<byte[]> root = factory.createRootBundle(created).commit(Instant.now());
-    UncommittedBundle<byte[]> keyed = factory.createKeyedBundle(root, "mykey", transformed);
+    UncommittedBundle<byte[]> keyed = factory.createKeyedBundle(root,
+        StructuralKey.of("mykey", StringUtf8Coder.of()),
+        transformed);
 
     byte[] array = new byte[] {4, 8, 12};
     WindowedValue<byte[]> windowedArray =

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
@@ -23,6 +23,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.coders.VarLongCoder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.FiredTimers;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate.TimerUpdateBuilder;
@@ -394,16 +397,18 @@ public class InMemoryWatermarkManagerTest implements Serializable {
    */
   @Test
   public void updateWatermarkWithKeyedWatermarkHolds() {
-    CommittedBundle<Integer> firstKeyBundle =
-        bundleFactory.createKeyedBundle(null, "Odd", createdInts)
-            .add(WindowedValue.timestampedValueInGlobalWindow(1, new Instant(1_000_000L)))
-            .add(WindowedValue.timestampedValueInGlobalWindow(3, new Instant(-1000L)))
-            .commit(clock.now());
+    CommittedBundle<Integer> firstKeyBundle = bundleFactory.createKeyedBundle(null,
+        StructuralKey.of("Odd", StringUtf8Coder.of()),
+        createdInts)
+        .add(WindowedValue.timestampedValueInGlobalWindow(1, new Instant(1_000_000L)))
+        .add(WindowedValue.timestampedValueInGlobalWindow(3, new Instant(-1000L)))
+        .commit(clock.now());
 
-    CommittedBundle<Integer> secondKeyBundle =
-        bundleFactory.createKeyedBundle(null, "Even", createdInts)
-            .add(WindowedValue.timestampedValueInGlobalWindow(2, new Instant(1234L)))
-            .commit(clock.now());
+    CommittedBundle<Integer> secondKeyBundle = bundleFactory.createKeyedBundle(null,
+        StructuralKey.of("Even", StringUtf8Coder.of()),
+        createdInts)
+        .add(WindowedValue.timestampedValueInGlobalWindow(2, new Instant(1234L)))
+        .commit(clock.now());
 
     manager.updateWatermarks(null,
         TimerUpdate.empty(),
@@ -432,8 +437,9 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         not(earlierThan(BoundedWindow.TIMESTAMP_MAX_VALUE)));
     assertThat(filteredWatermarks.getOutputWatermark(), not(laterThan(new Instant(-1000L))));
 
-    CommittedBundle<Integer> fauxFirstKeyTimerBundle =
-        bundleFactory.createKeyedBundle(null, "Odd", createdInts).commit(clock.now());
+    CommittedBundle<Integer> fauxFirstKeyTimerBundle = bundleFactory.createKeyedBundle(null,
+        StructuralKey.of("Odd", StringUtf8Coder.of()),
+        createdInts).commit(clock.now());
     manager.updateWatermarks(fauxFirstKeyTimerBundle,
         TimerUpdate.empty(),
         result(filtered.getProducingTransformInternal(),
@@ -444,8 +450,9 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
     assertThat(filteredWatermarks.getOutputWatermark(), equalTo(new Instant(1234L)));
 
-    CommittedBundle<Integer> fauxSecondKeyTimerBundle =
-        bundleFactory.createKeyedBundle(null, "Even", createdInts).commit(clock.now());
+    CommittedBundle<Integer> fauxSecondKeyTimerBundle = bundleFactory.createKeyedBundle(null,
+        StructuralKey.of("Even", StringUtf8Coder.of()),
+        createdInts).commit(clock.now());
     manager.updateWatermarks(fauxSecondKeyTimerBundle,
         TimerUpdate.empty(),
         result(filtered.getProducingTransformInternal(),
@@ -843,13 +850,14 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     Instant initialFilteredWm = filteredWms.getSynchronizedProcessingOutputTime();
     Instant initialFilteredDoubledWm = filteredDoubledWms.getSynchronizedProcessingOutputTime();
 
+    StructuralKey<String> key = StructuralKey.of("key", StringUtf8Coder.of());
     CommittedBundle<Integer> filteredBundle = multiWindowedBundle(filtered, 2, 8);
     TimerData pastTimer =
         TimerData.of(StateNamespaces.global(), new Instant(250L), TimeDomain.PROCESSING_TIME);
     TimerData futureTimer =
         TimerData.of(StateNamespaces.global(), new Instant(4096L), TimeDomain.PROCESSING_TIME);
     TimerUpdate timers =
-        TimerUpdate.builder("key").setTimer(pastTimer).setTimer(futureTimer).build();
+        TimerUpdate.builder(key).setTimer(pastTimer).setTimer(futureTimer).build();
     manager.updateWatermarks(createdBundle,
         timers,
         result(filtered.getProducingTransformInternal(),
@@ -869,11 +877,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         filteredDoubledWms.getSynchronizedProcessingOutputTime(),
         not(earlierThan(initialFilteredDoubledWm)));
 
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firedTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> firedTimers =
         manager.extractFiredTimers();
     assertThat(
         firedTimers.get(filtered.getProducingTransformInternal())
-            .get("key")
+            .get(key)
             .getTimers(TimeDomain.PROCESSING_TIME),
         contains(pastTimer));
     // Our timer has fired, but has not been completed, so it holds our synchronized processing WM
@@ -882,14 +890,14 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
     CommittedBundle<Integer> filteredTimerBundle =
         bundleFactory
-            .createKeyedBundle(null, "key", filtered)
+            .createKeyedBundle(null, key, filtered)
             .commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
     CommittedBundle<Integer> filteredTimerResult =
-        bundleFactory.createKeyedBundle(null, "key", filteredTimesTwo)
+        bundleFactory.createKeyedBundle(null, key, filteredTimesTwo)
             .commit(filteredWms.getSynchronizedProcessingOutputTime());
     // Complete the processing time timer
     manager.updateWatermarks(filteredTimerBundle,
-        TimerUpdate.builder("key")
+        TimerUpdate.builder(key)
             .withCompletedTimers(Collections.<TimerData>singleton(pastTimer)).build(),
         result(filtered.getProducingTransformInternal(),
             filteredTimerBundle.withElements(Collections.<WindowedValue<Integer>>emptyList()),
@@ -985,7 +993,9 @@ public class InMemoryWatermarkManagerTest implements Serializable {
     TimerData upstreamProcessingTimer =
         TimerData.of(StateNamespaces.global(), upstreamHold, TimeDomain.PROCESSING_TIME);
     manager.updateWatermarks(created,
-        TimerUpdate.builder("key").setTimer(upstreamProcessingTimer).build(),
+        TimerUpdate.builder(StructuralKey.of("key", StringUtf8Coder.of()))
+            .setTimer(upstreamProcessingTimer)
+            .build(),
         result(filtered.getProducingTransformInternal(),
             created.withElements(Collections.<WindowedValue<Integer>>emptyList()),
             Collections.<CommittedBundle<?>>singleton(filteredBundle)),
@@ -1006,7 +1016,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
     CommittedBundle<Integer> otherCreated = multiWindowedBundle(createdInts, 4, 8, 12);
     manager.updateWatermarks(otherCreated,
-        TimerUpdate.builder("key")
+        TimerUpdate.builder(StructuralKey.of("key", StringUtf8Coder.of()))
             .withCompletedTimers(Collections.singleton(upstreamProcessingTimer)).build(),
         result(filtered.getProducingTransformInternal(),
             otherCreated.withElements(Collections.<WindowedValue<Integer>>emptyList()),
@@ -1029,8 +1039,9 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         new Instant(29_919_235L));
 
     Instant upstreamHold = new Instant(2048L);
-    CommittedBundle<Integer> filteredBundle =
-        bundleFactory.createKeyedBundle(created, "key", filtered).commit(upstreamHold);
+    CommittedBundle<Integer> filteredBundle = bundleFactory.createKeyedBundle(created,
+        StructuralKey.of("key", StringUtf8Coder.of()),
+        filtered).commit(upstreamHold);
     manager.updateWatermarks(
         created,
         TimerUpdate.empty(),
@@ -1050,7 +1061,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
   @Test
   public void extractFiredTimersReturnsFiredEventTimeTimers() {
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> initialTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> initialTimers =
         manager.extractFiredTimers();
     // Watermarks haven't advanced
     assertThat(initialTimers.entrySet(), emptyIterable());
@@ -1071,7 +1082,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         TimerData.of(StateNamespaces.global(), new Instant(5000L), TimeDomain.EVENT_TIME);
     TimerData lastTimer =
         TimerData.of(StateNamespaces.global(), new Instant(10000L), TimeDomain.EVENT_TIME);
-    Object key = new Object();
+    StructuralKey<byte[]> key = StructuralKey.of(new byte[] {1, 4, 9}, ByteArrayCoder.of());
     TimerUpdate update =
         TimerUpdate.builder(key)
             .setTimer(earliestTimer)
@@ -1087,11 +1098,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         new Instant(1000L));
     manager.refreshAll();
 
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firstTransformFiredTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> firstTransformFiredTimers =
         manager.extractFiredTimers();
     assertThat(
         firstTransformFiredTimers.get(filtered.getProducingTransformInternal()), not(nullValue()));
-    Map<Object, FiredTimers> firstFilteredTimers =
+    Map<StructuralKey<?>, FiredTimers> firstFilteredTimers =
         firstTransformFiredTimers.get(filtered.getProducingTransformInternal());
     assertThat(firstFilteredTimers.get(key), not(nullValue()));
     FiredTimers firstFired = firstFilteredTimers.get(key);
@@ -1104,11 +1115,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
             Collections.<CommittedBundle<?>>emptyList()),
         new Instant(50_000L));
     manager.refreshAll();
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> secondTransformFiredTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> secondTransformFiredTimers =
         manager.extractFiredTimers();
     assertThat(
         secondTransformFiredTimers.get(filtered.getProducingTransformInternal()), not(nullValue()));
-    Map<Object, FiredTimers> secondFilteredTimers =
+    Map<StructuralKey<?>, FiredTimers> secondFilteredTimers =
         secondTransformFiredTimers.get(filtered.getProducingTransformInternal());
     assertThat(secondFilteredTimers.get(key), not(nullValue()));
     FiredTimers secondFired = secondFilteredTimers.get(key);
@@ -1118,7 +1129,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
   @Test
   public void extractFiredTimersReturnsFiredProcessingTimeTimers() {
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> initialTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> initialTimers =
         manager.extractFiredTimers();
     // Watermarks haven't advanced
     assertThat(initialTimers.entrySet(), emptyIterable());
@@ -1138,7 +1149,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         TimerData.of(StateNamespaces.global(), new Instant(5000L), TimeDomain.PROCESSING_TIME);
     TimerData lastTimer =
         TimerData.of(StateNamespaces.global(), new Instant(10000L), TimeDomain.PROCESSING_TIME);
-    Object key = new Object();
+    StructuralKey<?> key = StructuralKey.of(-12L, VarLongCoder.of());
     TimerUpdate update =
         TimerUpdate.builder(key)
             .setTimer(lastTimer)
@@ -1155,11 +1166,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         new Instant(1000L));
     manager.refreshAll();
 
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firstTransformFiredTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> firstTransformFiredTimers =
         manager.extractFiredTimers();
     assertThat(
         firstTransformFiredTimers.get(filtered.getProducingTransformInternal()), not(nullValue()));
-    Map<Object, FiredTimers> firstFilteredTimers =
+    Map<StructuralKey<?>, FiredTimers> firstFilteredTimers =
         firstTransformFiredTimers.get(filtered.getProducingTransformInternal());
     assertThat(firstFilteredTimers.get(key), not(nullValue()));
     FiredTimers firstFired = firstFilteredTimers.get(key);
@@ -1173,11 +1184,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
             Collections.<CommittedBundle<?>>emptyList()),
         new Instant(50_000L));
     manager.refreshAll();
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> secondTransformFiredTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> secondTransformFiredTimers =
         manager.extractFiredTimers();
     assertThat(
         secondTransformFiredTimers.get(filtered.getProducingTransformInternal()), not(nullValue()));
-    Map<Object, FiredTimers> secondFilteredTimers =
+    Map<StructuralKey<?>, FiredTimers> secondFilteredTimers =
         secondTransformFiredTimers.get(filtered.getProducingTransformInternal());
     assertThat(secondFilteredTimers.get(key), not(nullValue()));
     FiredTimers secondFired = secondFilteredTimers.get(key);
@@ -1187,7 +1198,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
 
   @Test
   public void extractFiredTimersReturnsFiredSynchronizedProcessingTimeTimers() {
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> initialTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> initialTimers =
         manager.extractFiredTimers();
     // Watermarks haven't advanced
     assertThat(initialTimers.entrySet(), emptyIterable());
@@ -1207,7 +1218,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         StateNamespaces.global(), new Instant(5000L), TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
     TimerData lastTimer = TimerData.of(
         StateNamespaces.global(), new Instant(10000L), TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
-    Object key = new Object();
+    StructuralKey<byte[]> key = StructuralKey.of(new byte[] {2, -2, 22}, ByteArrayCoder.of());
     TimerUpdate update =
         TimerUpdate.builder(key)
             .setTimer(lastTimer)
@@ -1224,11 +1235,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         new Instant(1000L));
     manager.refreshAll();
 
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> firstTransformFiredTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> firstTransformFiredTimers =
         manager.extractFiredTimers();
     assertThat(
         firstTransformFiredTimers.get(filtered.getProducingTransformInternal()), not(nullValue()));
-    Map<Object, FiredTimers> firstFilteredTimers =
+    Map<StructuralKey<?>, FiredTimers> firstFilteredTimers =
         firstTransformFiredTimers.get(filtered.getProducingTransformInternal());
     assertThat(firstFilteredTimers.get(key), not(nullValue()));
     FiredTimers firstFired = firstFilteredTimers.get(key);
@@ -1243,11 +1254,11 @@ public class InMemoryWatermarkManagerTest implements Serializable {
             Collections.<CommittedBundle<?>>emptyList()),
         new Instant(50_000L));
     manager.refreshAll();
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> secondTransformFiredTimers =
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> secondTransformFiredTimers =
         manager.extractFiredTimers();
     assertThat(
         secondTransformFiredTimers.get(filtered.getProducingTransformInternal()), not(nullValue()));
-    Map<Object, FiredTimers> secondFilteredTimers =
+    Map<StructuralKey<?>, FiredTimers> secondFilteredTimers =
         secondTransformFiredTimers.get(filtered.getProducingTransformInternal());
     assertThat(secondFilteredTimers.get(key), not(nullValue()));
     FiredTimers secondFired = secondFilteredTimers.get(key);
@@ -1268,7 +1279,7 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         TimerData.of(StateNamespaces.global(), new Instant(2048L), TimeDomain.EVENT_TIME);
 
     TimerUpdate update =
-        TimerUpdate.builder("foo")
+        TimerUpdate.builder(StructuralKey.of("foo", StringUtf8Coder.of()))
             .withCompletedTimers(ImmutableList.of(completedOne, completedTwo))
             .setTimer(set)
             .deletedTimer(deleted)

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleFactoryTest.java
@@ -17,9 +17,13 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
+import com.google.cloud.dataflow.sdk.coders.VoidCoder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
@@ -66,34 +70,38 @@ public class InProcessBundleFactoryTest {
   }
 
   @Test
-  public void createRootBundleShouldCreateWithNullKey() {
+  public void createRootBundleShouldCreateWithEmptyKey() {
     PCollection<Integer> pcollection = TestPipeline.create().apply(Create.of(1));
 
     UncommittedBundle<Integer> inFlightBundle = bundleFactory.createRootBundle(pcollection);
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
 
-    assertThat(bundle.getKey(), nullValue());
+    assertThat(bundle.getKey(),
+        Matchers.<StructuralKey<?>>equalTo(StructuralKey.of(null, VoidCoder.of())));
   }
 
-  private void createKeyedBundle(Object key) {
+  private <T> void createKeyedBundle(Coder<T> coder, T key) throws Exception {
     PCollection<Integer> pcollection = TestPipeline.create().apply(Create.of(1));
+    StructuralKey skey = StructuralKey.of(key, coder);
 
     UncommittedBundle<Integer> inFlightBundle =
-        bundleFactory.createKeyedBundle(null, key, pcollection);
+        bundleFactory.createKeyedBundle(null, skey, pcollection);
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
-    assertThat(bundle.getKey(), equalTo(key));
+    assertThat(bundle.getKey(), equalTo(skey));
   }
 
   @Test
-  public void keyedWithNullKeyShouldCreateKeyedBundle() {
-    createKeyedBundle(null);
+  public void keyedWithNullKeyShouldCreateKeyedBundle() throws Exception {
+    createKeyedBundle(VoidCoder.of(), null);
   }
 
   @Test
-  public void keyedWithKeyShouldCreateKeyedBundle() {
-    createKeyedBundle(new Object());
+  public void keyedWithKeyShouldCreateKeyedBundle() throws Exception {
+    createKeyedBundle(StringUtf8Coder.of(), "foo");
+    createKeyedBundle(VarIntCoder.of(), 1234);
+    createKeyedBundle(ByteArrayCoder.of(), new byte[] {0, 2, 4, 99});
   }
 
   private <T> CommittedBundle<T>
@@ -151,7 +159,7 @@ public class InProcessBundleFactoryTest {
 
     assertThat(withed.getElements(), containsInAnyOrder(firstReplacement, secondReplacement));
     assertThat(committed.getElements(), containsInAnyOrder(firstValue, secondValue));
-    assertThat(withed.getKey(), equalTo(committed.getKey()));
+    assertThat(withed.getKey(), Matchers.<StructuralKey<?>>equalTo(committed.getKey()));
     assertThat(withed.getPCollection(), equalTo(committed.getPCollection()));
     assertThat(
         withed.getSynchronizedProcessingOutputWatermark(),
@@ -200,21 +208,21 @@ public class InProcessBundleFactoryTest {
   @Test
   public void createBundleKeyedResultPropagatesKey() {
     CommittedBundle<KV<String, Integer>> newBundle =
-        bundleFactory
-            .createBundle(
-                bundleFactory.createKeyedBundle(null, "foo", created).commit(Instant.now()),
-                downstream)
-            .commit(Instant.now());
-    assertThat(newBundle.getKey(), Matchers.<Object>equalTo("foo"));
+        bundleFactory.createBundle(
+            bundleFactory.createKeyedBundle(
+                null,
+                StructuralKey.of("foo", StringUtf8Coder.of()),
+                created).commit(Instant.now()),
+            downstream).commit(Instant.now());
+    assertThat(newBundle.getKey().getKey(), Matchers.<Object>equalTo("foo"));
   }
 
   @Test
   public void createKeyedBundleKeyed() {
-    CommittedBundle<KV<String, Integer>> keyedBundle =
-        bundleFactory
-            .createKeyedBundle(
-                bundleFactory.createRootBundle(created).commit(Instant.now()), "foo", downstream)
-            .commit(Instant.now());
-    assertThat(keyedBundle.getKey(), Matchers.<Object>equalTo("foo"));
+    CommittedBundle<KV<String, Integer>> keyedBundle = bundleFactory.createKeyedBundle(
+        bundleFactory.createRootBundle(created).commit(Instant.now()),
+        StructuralKey.of("foo", StringUtf8Coder.of()),
+        downstream).commit(Instant.now());
+    assertThat(keyedBundle.getKey().getKey(), Matchers.<Object>equalTo("foo"));
   }
 }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContextTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContextTest.java
@@ -23,6 +23,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
 import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
 import com.google.cloud.dataflow.sdk.io.CountingInput;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
@@ -156,16 +158,16 @@ public class InProcessEvaluationContextTest {
   @Test
   public void getExecutionContextSameStepSameKeyState() {
     InProcessExecutionContext fooContext =
-        context.getExecutionContext(created.getProducingTransformInternal(), "foo");
+        context.getExecutionContext(created.getProducingTransformInternal(),
+            StructuralKey.of("foo", StringUtf8Coder.of()));
 
     StateTag<Object, BagState<Integer>> intBag = StateTags.bag("myBag", VarIntCoder.of());
 
     InProcessStepContext stepContext = fooContext.getOrCreateStepContext("s1", "s1", null);
     stepContext.stateInternals().state(StateNamespaces.global(), intBag).add(1);
 
-    context.handleResult(
-        InProcessBundleFactory.create()
-            .createKeyedBundle(null, "foo", created)
+    context.handleResult(InProcessBundleFactory.create()
+            .createKeyedBundle(null, StructuralKey.of("foo", StringUtf8Coder.of()), created)
             .commit(Instant.now()),
         ImmutableList.<TimerData>of(),
         StepTransformResult.withoutHold(created.getProducingTransformInternal())
@@ -173,7 +175,8 @@ public class InProcessEvaluationContextTest {
             .build());
 
     InProcessExecutionContext secondFooContext =
-        context.getExecutionContext(created.getProducingTransformInternal(), "foo");
+        context.getExecutionContext(created.getProducingTransformInternal(),
+            StructuralKey.of("foo", StringUtf8Coder.of()));
     assertThat(
         secondFooContext
             .getOrCreateStepContext("s1", "s1", null)
@@ -187,7 +190,8 @@ public class InProcessEvaluationContextTest {
   @Test
   public void getExecutionContextDifferentKeysIndependentState() {
     InProcessExecutionContext fooContext =
-        context.getExecutionContext(created.getProducingTransformInternal(), "foo");
+        context.getExecutionContext(created.getProducingTransformInternal(),
+            StructuralKey.of("foo", StringUtf8Coder.of()));
 
     StateTag<Object, BagState<Integer>> intBag = StateTags.bag("myBag", VarIntCoder.of());
 
@@ -198,7 +202,8 @@ public class InProcessEvaluationContextTest {
         .add(1);
 
     InProcessExecutionContext barContext =
-        context.getExecutionContext(created.getProducingTransformInternal(), "bar");
+        context.getExecutionContext(created.getProducingTransformInternal(),
+            StructuralKey.of("bar", StringUtf8Coder.of()));
     assertThat(barContext, not(equalTo(fooContext)));
     assertThat(
         barContext
@@ -211,7 +216,7 @@ public class InProcessEvaluationContextTest {
 
   @Test
   public void getExecutionContextDifferentStepsIndependentState() {
-    String myKey = "foo";
+    StructuralKey<?> myKey = StructuralKey.of("foo", StringUtf8Coder.of());
     InProcessExecutionContext fooContext =
         context.getExecutionContext(created.getProducingTransformInternal(), myKey);
 
@@ -266,7 +271,7 @@ public class InProcessEvaluationContextTest {
 
   @Test
   public void handleResultStoresState() {
-    String myKey = "foo";
+    StructuralKey<?> myKey = StructuralKey.of("foo".getBytes(), ByteArrayCoder.of());
     InProcessExecutionContext fooContext =
         context.getExecutionContext(downstream.getProducingTransformInternal(), myKey);
 
@@ -356,7 +361,7 @@ public class InProcessEvaluationContextTest {
             .build();
     context.handleResult(null, ImmutableList.<TimerData>of(), holdResult);
 
-    String key = "foo";
+    StructuralKey<?> key = StructuralKey.of("foo".length(), VarIntCoder.of());
     TimerData toFire =
         TimerData.of(StateNamespaces.global(), new Instant(100L), TimeDomain.EVENT_TIME);
     InProcessTransformResult timerResult =
@@ -380,11 +385,12 @@ public class InProcessEvaluationContextTest {
     // Should cause the downstream timer to fire
     context.handleResult(null, ImmutableList.<TimerData>of(), advanceResult);
 
-    Map<AppliedPTransform<?, ?, ?>, Map<Object, FiredTimers>> fired = context.extractFiredTimers();
+    Map<AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> fired =
+        context.extractFiredTimers();
     assertThat(
         fired,
         Matchers.<AppliedPTransform<?, ?, ?>>hasKey(downstream.getProducingTransformInternal()));
-    Map<Object, FiredTimers> downstreamFired =
+    Map<StructuralKey<?>, FiredTimers> downstreamFired =
         fired.get(downstream.getProducingTransformInternal());
     assertThat(downstreamFired, Matchers.<Object>hasKey(key));
 
@@ -399,23 +405,27 @@ public class InProcessEvaluationContextTest {
 
   @Test
   public void createBundleKeyedResultPropagatesKey() {
+    StructuralKey<String> key = StructuralKey.of("foo", StringUtf8Coder.of());
     CommittedBundle<KV<String, Integer>> newBundle =
         context
             .createBundle(
-                bundleFactory.createKeyedBundle(null, "foo", created).commit(Instant.now()),
-                downstream)
-            .commit(Instant.now());
-    assertThat(newBundle.getKey(), Matchers.<Object>equalTo("foo"));
+                bundleFactory.createKeyedBundle(
+                    null, key,
+                    created).commit(Instant.now()),
+                downstream).commit(Instant.now());
+    assertThat(newBundle.getKey(), Matchers.<StructuralKey<?>>equalTo(key));
   }
 
   @Test
   public void createKeyedBundleKeyed() {
+    StructuralKey<String> key = StructuralKey.of("foo", StringUtf8Coder.of());
     CommittedBundle<KV<String, Integer>> keyedBundle =
-        context
-            .createKeyedBundle(
-                bundleFactory.createRootBundle(created).commit(Instant.now()), "foo", downstream)
-            .commit(Instant.now());
-    assertThat(keyedBundle.getKey(), Matchers.<Object>equalTo("foo"));
+        context.createKeyedBundle(
+            bundleFactory.createRootBundle(created).commit(Instant.now()),
+            key,
+            downstream).commit(Instant.now());
+    assertThat(keyedBundle.getKey(),
+        Matchers.<StructuralKey<?>>equalTo(key));
   }
 
   @Test

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTimerInternalsTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTimerInternalsTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate.TimerUpdateBuilder;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TransformWatermarks;
@@ -53,7 +54,7 @@ public class InProcessTimerInternalsTest {
     MockitoAnnotations.initMocks(this);
     clock = MockClock.fromInstant(new Instant(0));
 
-    timerUpdateBuilder = TimerUpdate.builder(1234);
+    timerUpdateBuilder = TimerUpdate.builder(StructuralKey.of(1234, VarIntCoder.of()));
 
     internals = InProcessTimerInternals.create(clock, watermarks, timerUpdateBuilder);
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoInProcessEvaluatorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoInProcessEvaluatorTest.java
@@ -151,7 +151,7 @@ public class ParDoInProcessEvaluatorTest {
     when(stepContext.getTimerUpdate()).thenReturn(TimerUpdate.empty());
     when(
             evaluationContext.getExecutionContext(
-                Mockito.any(AppliedPTransform.class), Mockito.any(Object.class)))
+                Mockito.any(AppliedPTransform.class), Mockito.any(StructuralKey.class)))
         .thenReturn(executionContext);
     when(evaluationContext.createCounterSet()).thenReturn(new CounterSet());
 

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoMultiEvaluatorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoMultiEvaluatorFactoryTest.java
@@ -112,8 +112,8 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
 
     InProcessExecutionContext executionContext =
         new InProcessExecutionContext(null, null, null, null);
-    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(), null))
-        .thenReturn(executionContext);
+    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(),
+        inputBundle.getKey())).thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
 
@@ -197,8 +197,8 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
 
     InProcessExecutionContext executionContext =
         new InProcessExecutionContext(null, null, null, null);
-    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(), null))
-        .thenReturn(executionContext);
+    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(),
+        inputBundle.getKey())).thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
 
@@ -285,10 +285,12 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.createBundle(inputBundle, elementOutput))
         .thenReturn(elementOutputBundle);
 
-    InProcessExecutionContext executionContext =
-        new InProcessExecutionContext(null, "myKey", null, null);
-    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(), null))
-        .thenReturn(executionContext);
+    InProcessExecutionContext executionContext = new InProcessExecutionContext(null,
+        StructuralKey.of("myKey", StringUtf8Coder.of()),
+        null,
+        null);
+    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(),
+        inputBundle.getKey())).thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
 
@@ -395,10 +397,11 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.createBundle(inputBundle, elementOutput))
         .thenReturn(elementOutputBundle);
 
-    InProcessExecutionContext executionContext =
-        new InProcessExecutionContext(null, "myKey", null, null);
-    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(), null))
-        .thenReturn(executionContext);
+    InProcessExecutionContext executionContext = new InProcessExecutionContext(null,
+        StructuralKey.of("myKey", StringUtf8Coder.of()),
+        null, null);
+    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(),
+        inputBundle.getKey())).thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
 
@@ -417,7 +420,7 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     assertThat(
         result.getTimerUpdate(),
         equalTo(
-            TimerUpdate.builder("myKey")
+            TimerUpdate.builder(StructuralKey.of("myKey", StringUtf8Coder.of()))
                 .setTimer(addedTimer)
                 .setTimer(addedTimer)
                 .setTimer(addedTimer)

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoSingleEvaluatorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/ParDoSingleEvaluatorFactoryTest.java
@@ -88,8 +88,8 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.createBundle(inputBundle, collection)).thenReturn(outputBundle);
     InProcessExecutionContext executionContext =
         new InProcessExecutionContext(null, null, null, null);
-    when(evaluationContext.getExecutionContext(collection.getProducingTransformInternal(), null))
-        .thenReturn(executionContext);
+    when(evaluationContext.getExecutionContext(collection.getProducingTransformInternal(),
+        inputBundle.getKey())).thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
 
@@ -140,8 +140,8 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.createBundle(inputBundle, collection)).thenReturn(outputBundle);
     InProcessExecutionContext executionContext =
         new InProcessExecutionContext(null, null, null, null);
-    when(evaluationContext.getExecutionContext(collection.getProducingTransformInternal(), null))
-        .thenReturn(executionContext);
+    when(evaluationContext.getExecutionContext(collection.getProducingTransformInternal(),
+        inputBundle.getKey())).thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
 
@@ -202,9 +202,11 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
 
     when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
 
-    InProcessExecutionContext executionContext =
-        new InProcessExecutionContext(null, "myKey", null, null);
-    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(), null))
+    InProcessExecutionContext executionContext = new InProcessExecutionContext(null,
+        StructuralKey.of("myKey", StringUtf8Coder.of()),
+        null, null);
+    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(),
+        inputBundle.getKey()))
         .thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
@@ -290,6 +292,7 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
             });
     PCollection<KV<String, Integer>> mainOutput = input.apply(pardo);
 
+    StructuralKey<?> key = StructuralKey.of("myKey", StringUtf8Coder.of());
     CommittedBundle<String> inputBundle =
         bundleFactory.createRootBundle(input).commit(Instant.now());
 
@@ -299,9 +302,12 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
 
     when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
 
-    InProcessExecutionContext executionContext =
-        new InProcessExecutionContext(null, "myKey", null, null);
-    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(), null))
+    InProcessExecutionContext executionContext = new InProcessExecutionContext(null,
+        key,
+        null,
+        null);
+    when(evaluationContext.getExecutionContext(mainOutput.getProducingTransformInternal(),
+        inputBundle.getKey()))
         .thenReturn(executionContext);
     CounterSet counters = new CounterSet();
     when(evaluationContext.createCounterSet()).thenReturn(counters);
@@ -314,10 +320,11 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
 
     InProcessTransformResult result = evaluator.finishBundle();
-    assertThat(
-        result.getTimerUpdate(),
-        equalTo(
-            TimerUpdate.builder("myKey").setTimer(addedTimer).deletedTimer(deletedTimer).build()));
+    assertThat(result.getTimerUpdate(),
+        equalTo(TimerUpdate.builder(StructuralKey.of("myKey", StringUtf8Coder.of()))
+            .setTimer(addedTimer)
+            .deletedTimer(deletedTimer)
+            .build()));
   }
 }
 

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/StructuralKeyTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/StructuralKeyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.theInstance;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link StructuralKey}.
+ */
+@RunWith(JUnit4.class)
+public class StructuralKeyTest {
+  @Test
+  public void getKeyEqualToOldKey() {
+    assertThat(StructuralKey.of(1234, VarIntCoder.of()).getKey(), equalTo(1234));
+    assertThat(StructuralKey.of("foobar", StringUtf8Coder.of()).getKey(), equalTo("foobar"));
+    assertArrayEquals(StructuralKey.of(new byte[] {2, 9, -22}, ByteArrayCoder.of()).getKey(),
+        new byte[] {2, 9, -22});
+  }
+
+  @Test
+  public void getKeyNotSameInstance() {
+    byte[] original = new byte[] {1, 4, 9, 127, -22};
+    StructuralKey<byte[]> key = StructuralKey.of(original, ByteArrayCoder.of());
+
+    assertThat(key.getKey(), not(theInstance(original)));
+  }
+
+  @Test
+  public void objectEqualsTrueKeyEquals() {
+    StructuralKey<Integer> original = StructuralKey.of(1234, VarIntCoder.of());
+    assertThat(StructuralKey.of(1234, VarIntCoder.of()), equalTo(original));
+  }
+
+  @Test
+  public void objectsNotEqualEncodingsEqualEquals() {
+    byte[] original = new byte[] {1, 4, 9, 127, -22};
+    StructuralKey<byte[]> key = StructuralKey.of(original, ByteArrayCoder.of());
+
+    StructuralKey<byte[]> otherKey =
+        StructuralKey.of(new byte[] {1, 4, 9, 127, -22}, ByteArrayCoder.of());
+    assertThat(key, equalTo(otherKey));
+  }
+
+  @Test
+  public void notEqualEncodingsEqual() {
+    byte[] original = new byte[] {1, 4, 9, 127, -22};
+    StructuralKey<byte[]> key = StructuralKey.of(original, ByteArrayCoder.of());
+
+    StructuralKey<byte[]> otherKey =
+        StructuralKey.of(new byte[] {9, -128, 22}, ByteArrayCoder.of());
+    assertThat(key, not(equalTo(otherKey)));
+  }
+}


### PR DESCRIPTION
This fixes problems with lookup by basing entirely on structural
equality.

Backports [Beam PR 411](https://github.com/apache/incubator-beam/pull/411)