### PR TITLE
Reduce Visibility of InProcessPipelineRunner implementations

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -261,7 +261,7 @@
           <overview>../javadoc/overview.html</overview>
 
           <subpackages>com.google.cloud.dataflow.sdk</subpackages>
-          <additionalparam>-exclude com.google.cloud.dataflow.sdk.runners.worker:com.google.cloud.dataflow.sdk.runners.dataflow:com.google.cloud.dataflow.sdk.util:com.google.cloud.dataflow.sdk.runners.inprocess ${dataflow.javadoc_opts}</additionalparam>
+          <additionalparam>-exclude com.google.cloud.dataflow.sdk.runners.worker:com.google.cloud.dataflow.sdk.runners.dataflow:com.google.cloud.dataflow.sdk.util ${dataflow.javadoc_opts}</additionalparam>
           <use>false</use>
           <quiet>true</quiet>
           <bottom><![CDATA[<br>]]></bottom>

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BundleFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/BundleFactory.java
@@ -24,7 +24,7 @@ import com.google.cloud.dataflow.sdk.values.PCollection;
 /**
  * A factory that creates {@link UncommittedBundle UncommittedBundles}.
  */
-public interface BundleFactory {
+interface BundleFactory {
   /**
    * Create an {@link UncommittedBundle} from an empty input. Elements added to the bundle belong to
    * the {@code output} {@link PCollection}.

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ConsumerTrackingPipelineVisitor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ConsumerTrackingPipelineVisitor.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * {@link Pipeline}. This is used to schedule consuming {@link PTransform PTransforms} to consume
  * input after the upstream transform has produced and committed output.
  */
-public class ConsumerTrackingPipelineVisitor implements PipelineVisitor {
+class ConsumerTrackingPipelineVisitor implements PipelineVisitor {
   private Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers = new HashMap<>();
   private Collection<AppliedPTransform<?, ?, ?>> rootTransforms = new ArrayList<>();
   private Collection<PCollectionView<?>> views = new ArrayList<>();

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
@@ -122,7 +122,7 @@ import javax.annotation.Nullable;
  * Watermark_PCollection = Watermark_Out_ProducingPTransform
  * </pre>
  */
-public class InMemoryWatermarkManager {
+class InMemoryWatermarkManager {
   /**
    * The watermark of some {@link Pipeline} element, usually a {@link PTransform} or a
    * {@link PCollection}.

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleOutputManager.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessBundleOutputManager.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * An {@link OutputManager} that outputs to {@link CommittedBundle Bundles} used by the
  * {@link InProcessPipelineRunner}.
  */
-public class InProcessBundleOutputManager implements OutputManager {
+class InProcessBundleOutputManager implements OutputManager {
   private final Map<TupleTag<?>, UncommittedBundle<?>> bundles;
 
   public static InProcessBundleOutputManager create(

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTimerInternals.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTimerInternals.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 /**
  * An implementation of {@link TimerInternals} where all relevant data exists in memory.
  */
-public class InProcessTimerInternals implements TimerInternals {
+class InProcessTimerInternals implements TimerInternals {
   private final Clock processingTimeClock;
   private final TransformWatermarks watermarks;
   private final TimerUpdateBuilder timerUpdateBuilder;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 /**
  * The result of evaluating an {@link AppliedPTransform} with a {@link TransformEvaluator}.
  */
-public interface InProcessTransformResult {
+interface InProcessTransformResult {
   /**
    * Returns the {@link AppliedPTransform} that produced this result.
    */

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepTransformResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepTransformResult.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 /**
  * An immutable {@link InProcessTransformResult}.
  */
-public class StepTransformResult implements InProcessTransformResult {
+class StepTransformResult implements InProcessTransformResult {
   private final AppliedPTransform<?, ?, ?> transform;
   private final Iterable<? extends UncommittedBundle<?>> bundles;
   private final Iterable<? extends WindowedValue<?>> unprocessedElements;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluator.java
@@ -24,7 +24,7 @@ import com.google.cloud.dataflow.sdk.util.WindowedValue;
  *
  * @param <InputT> the type of elements that will be passed to {@link #processElement}
  */
-public interface TransformEvaluator<InputT> {
+interface TransformEvaluator<InputT> {
   /**
    * Process an element in the input {@link CommittedBundle}.
    *

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorFactory.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * A factory for creating instances of {@link TransformEvaluator} for the application of a
  * {@link PTransform}.
  */
-public interface TransformEvaluatorFactory {
+interface TransformEvaluatorFactory {
   /**
    * Create a new {@link TransformEvaluator} for the application of the {@link PTransform}.
    *


### PR DESCRIPTION
Only publicly used elements are visible.

Remove javadoc exclusion for the runner.