### PR TITLE
Update docs on per-window tables

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -225,8 +225,6 @@ import javax.annotation.Nullable;
  *         }));
  * }</pre>
  *
- * <p>Per-window tables are not yet supported in batch mode.
- *
  * <h3>Permissions</h3>
  * <p>Permission requirements depend on the {@link PipelineRunner} that is used to execute the
  * Dataflow job. Please refer to the documentation of corresponding {@link PipelineRunner}s for


### PR DESCRIPTION
We've been using per-window tables using the described method for a while now in batch pipelines with no issues. I'm assuming this doc is out of date, so proposing this change.