### PR TITLE
Use a DirectExecutor for Watermark Callbacks

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -43,13 +43,13 @@ import com.google.cloud.dataflow.sdk.values.PValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
 
@@ -127,7 +127,7 @@ class InProcessEvaluationContext {
     this.applicationStateInternals = new ConcurrentHashMap<>();
     this.mergedCounters = new CounterSet();
 
-    this.callbackExecutor = WatermarkCallbackExecutor.create(Executors.newSingleThreadExecutor());
+    this.callbackExecutor = WatermarkCallbackExecutor.create(MoreExecutors.directExecutor());
   }
 
   /**

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/WatermarkCallbackExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/WatermarkCallbackExecutor.java
@@ -26,7 +26,7 @@ import org.joda.time.Instant;
 import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 /**
  * Executes callbacks that occur based on the progression of the watermark per-step.
@@ -48,15 +48,15 @@ class WatermarkCallbackExecutor {
   /**
    * Create a new {@link WatermarkCallbackExecutor}.
    */
-  public static WatermarkCallbackExecutor create(ExecutorService executor) {
+  public static WatermarkCallbackExecutor create(Executor executor) {
     return new WatermarkCallbackExecutor(executor);
   }
 
   private final ConcurrentMap<AppliedPTransform<?, ?, ?>, PriorityQueue<WatermarkCallback>>
       callbacks;
-  private final ExecutorService executor;
+  private final Executor executor;
 
-  private WatermarkCallbackExecutor(ExecutorService executor) {
+  private WatermarkCallbackExecutor(Executor executor) {
     this.callbacks = new ConcurrentHashMap<>();
     this.executor = executor;
   }
@@ -98,7 +98,7 @@ class WatermarkCallbackExecutor {
     }
     synchronized (callbackQueue) {
       while (!callbackQueue.isEmpty() && callbackQueue.peek().shouldFire(watermark)) {
-        executor.submit(callbackQueue.poll().getCallback());
+        executor.execute(callbackQueue.poll().getCallback());
       }
     }
   }


### PR DESCRIPTION
This fixes a resource leak where the executor service is not properly
shut down with the rest of the InProcessPipelineRunner.