### PR TITLE
Backport: Disable exec-maven-plugin cleanupDaemonThreads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
             </execution>
           </executions>
           <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
             <systemProperties>
               <systemProperty>
                 <key>java.util.logging.config.file</key>


### PR DESCRIPTION
exec-maven-plugin has a bad interaction with DataflowPipelineRunner
when waiting on daemon threads. When running example pipelines,
Maven will emit a warning saying background threads are alive
after being aborted. This looks to users like an error while there's
actually no harm to it. Disabling cleanupDaemonThreads suppresses
this warning.

(cherry picked from commit 70ba4f0dd63d564205b58d0ba4e5215f6802f8c9)