### PR TITLE
Backport: Port cleanupDaemonThreads fix to archetype module

### DIFF
--- a/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -87,6 +87,19 @@
         </dependencies>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.4.0</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencies>

--- a/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
+++ b/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
@@ -19,6 +19,19 @@
         </configuration>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.4.0</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencies>

--- a/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
+++ b/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
@@ -19,6 +19,19 @@
         </configuration>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.4.0</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencies>


### PR DESCRIPTION
(cherry picked from commit 51030829ef53001eb7db608fd56bcf1b4bea4249)

---
The changes for the backport are a manually-apply of the diff from the above change because the files have been moved to a different location and Git wasn't able to figure it out automatically.