### PR TITLE
Backport: Make example AddTimestampFn range deterministic

### DIFF
--- a/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/WindowedWordCount.java
@@ -122,13 +122,18 @@ public class WindowedWordCount {
    * 2-hour period.
    */
   static class AddTimestampFn extends DoFn<String, String> {
-    private static final long RAND_RANGE = 7200000; // 2 hours in ms
+    private static final Duration RAND_RANGE = Duration.standardHours(2);
+    private final Instant minTimestamp;
+
+    AddTimestampFn() {
+      this.minTimestamp = new Instant(System.currentTimeMillis());
+    }
 
     @Override
     public void processElement(ProcessContext c) {
       // Generate a timestamp that falls somewhere in the past two hours.
-      long randomTimestamp = System.currentTimeMillis()
-        - (int) (Math.random() * RAND_RANGE);
+      long randMillis = (long) (Math.random() * RAND_RANGE.getMillis());
+      Instant randomTimestamp = minTimestamp.plus(randMillis);
       /**
        * Concept #2: Set the data element with that timestamp.
        */


### PR DESCRIPTION
The timestamps added in the WindowedWordCount example are currently
based on when the bundles are executed, which makes the min/max bounds
non-deterministic. This change makes the range  based on the
construction time.

(cherry picked from commit 335202a033ced6f30f1b0e5df9da047241abc750)