### PR TITLE
Backport: Package javadoc for org.apache.beam.sdk.transforms.display

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/display/package-info.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/display/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Defines {@link com.google.cloud.dataflow.sdk.transforms.display.HasDisplayData} for annotating
+ * components which provide
+ * {@link com.google.cloud.dataflow.sdk.transforms.display.DisplayData display data} used within UIs
+ * and diagnostic tools.
+ *
+ * @see com.google.cloud.dataflow.sdk.transforms.display.HasDisplayData
+ */
+package com.google.cloud.dataflow.sdk.transforms.display;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/display/package-info.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/display/package-info.java
@@ -1,19 +1,17 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright (C) 2016 Google Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 /**


### PR DESCRIPTION
(cherry picked from commit 2e0836e730c52c0ef7137f67495f43bb4ec2b06a)