### PR TITLE
Backport: Fix NullPointerException in AfterWatermark display data

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermark.java
@@ -30,6 +30,8 @@ import org.joda.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>{@code AfterWatermark} triggers fire based on progress of the system watermark. This time is a
  * lower-bound, sometimes heuristically established, on event times that have been fully processed
@@ -144,6 +146,7 @@ public class AfterWatermark<W extends BoundedWindow> {
     private static final int LATE_INDEX = 1;
 
     private final OnceTrigger<W> earlyTrigger;
+    @Nullable
     private final OnceTrigger<W> lateTrigger;
 
     @SuppressWarnings("unchecked")
@@ -264,7 +267,6 @@ public class AfterWatermark<W extends BoundedWindow> {
     public String toString() {
       StringBuilder builder = new StringBuilder(TO_STRING);
 
-      Trigger earlyTrigger = subTriggers.get(EARLY_INDEX);
       if (!(earlyTrigger instanceof NeverTrigger)) {
         builder
             .append(".withEarlyFirings(")
@@ -272,10 +274,12 @@ public class AfterWatermark<W extends BoundedWindow> {
             .append(")");
       }
 
-      builder
-          .append(".withLateFirings(")
-          .append(subTriggers.get(LATE_INDEX))
-          .append(")");
+      if (lateTrigger != null && !(lateTrigger instanceof Never.NeverTrigger)) {
+        builder
+            .append(".withLateFirings(")
+            .append(lateTrigger)
+            .append(")");
+      }
 
       return builder.toString();
     }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermark.java
@@ -274,7 +274,7 @@ public class AfterWatermark<W extends BoundedWindow> {
             .append(")");
       }
 
-      if (lateTrigger != null && !(lateTrigger instanceof Never.NeverTrigger)) {
+      if (lateTrigger != null && !(lateTrigger instanceof NeverTrigger)) {
         builder
             .append(".withLateFirings(")
             .append(lateTrigger)

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermarkTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermarkTest.java
@@ -362,16 +362,6 @@ public class AfterWatermarkTest {
   }
 
   @Test
-  public void testToStringExcludesNeverTrigger() {
-    Trigger trigger = AfterWatermark.pastEndOfWindow()
-        .withEarlyFirings(Never.ever())
-        .withLateFirings(Never.ever())
-        .buildTrigger();
-
-    assertEquals("AfterWatermark.pastEndOfWindow()", trigger.toString());
-  }
-
-  @Test
   public void testEarlyAndLateFiringsToString() {
     Trigger trigger = AfterWatermark.pastEndOfWindow()
         .withEarlyFirings(StubTrigger.named("t1"))

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermarkTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/windowing/AfterWatermarkTest.java
@@ -344,12 +344,31 @@ public class AfterWatermarkTest {
   }
 
   @Test
+  public void testEarlyFiringsToString() {
+    Trigger trigger = AfterWatermark.pastEndOfWindow()
+        .withEarlyFirings(StubTrigger.named("t1"))
+        .buildTrigger();
+
+    assertEquals("AfterWatermark.pastEndOfWindow().withEarlyFirings(t1)", trigger.toString());
+  }
+
+  @Test
   public void testLateFiringsToString() {
     Trigger trigger = AfterWatermark.pastEndOfWindow()
         .withLateFirings(StubTrigger.named("t1"))
         .buildTrigger();
 
     assertEquals("AfterWatermark.pastEndOfWindow().withLateFirings(t1)", trigger.toString());
+  }
+
+  @Test
+  public void testToStringExcludesNeverTrigger() {
+    Trigger trigger = AfterWatermark.pastEndOfWindow()
+        .withEarlyFirings(Never.ever())
+        .withLateFirings(Never.ever())
+        .buildTrigger();
+
+    assertEquals("AfterWatermark.pastEndOfWindow()", trigger.toString());
   }
 
   @Test


### PR DESCRIPTION
Window transforms register display data for the associated trigger
function by calling its .toString() method. The AfterWatermark
trigger .toString() method was not properly handling cases where
there is no late firings registered.

(cherry picked from commit e7f2f582afd48bf5e2aacb3a36471377cb927018)