### PR TITLE
Backport from Beam: Increase the MESSAGES_POLLING_ATTEMPTS for slow backend starts

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineJob.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineJob.java
@@ -99,7 +99,7 @@ public class DataflowPipelineJob implements PipelineResult {
   /**
    * The amount of polling attempts for job status and messages information.
    */
-  static final int MESSAGES_POLLING_ATTEMPTS = 10;
+  static final int MESSAGES_POLLING_ATTEMPTS = 12;
   static final int STATUS_POLLING_ATTEMPTS = 5;
 
   /**


### PR DESCRIPTION
This is backport from: https://github.com/apache/incubator-beam/pull/549