### PR TITLE
AvroSource: use a 64K buffer size for Snappy codec

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/AvroSource.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/AvroSource.java
@@ -393,7 +393,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
       ByteArrayInputStream byteStream = new ByteArrayInputStream(data);
       switch (codec) {
         case DataFileConstants.SNAPPY_CODEC:
-          return new SnappyCompressorInputStream(byteStream);
+          return new SnappyCompressorInputStream(byteStream, 1 << 16 /* Avro uses 64KB blocks. */);
         case DataFileConstants.DEFLATE_CODEC:
           // nowrap == true: Do not expect ZLIB header or checksum, as Avro does not write them.
           Inflater inflater = new Inflater(true);

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/AvroSourceTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/AvroSourceTest.java
@@ -132,10 +132,17 @@ public class AvroSourceTest {
   @Test
   public void testReadWithDifferentCodecs() throws Exception {
     // Test reading files generated using all codecs.
-    String codecs[] = {DataFileConstants.NULL_CODEC, DataFileConstants.BZIP2_CODEC,
-        DataFileConstants.DEFLATE_CODEC, DataFileConstants.SNAPPY_CODEC,
-        DataFileConstants.XZ_CODEC};
-    List<Bird> expected = createRandomRecords(DEFAULT_RECORD_COUNT);
+    String codecs[] = {
+        DataFileConstants.NULL_CODEC,
+        DataFileConstants.BZIP2_CODEC,
+        DataFileConstants.DEFLATE_CODEC,
+        DataFileConstants.SNAPPY_CODEC,
+        DataFileConstants.XZ_CODEC,
+    };
+    // As Avro's default block size is 64KB, write 64K records to ensure at least one full block.
+    // We could make this smaller than 64K assuming each record is at least B bytes, but then the
+    // test could silently stop testing the failure condition from BEAM-422.
+    List<Bird> expected = createRandomRecords(1 << 16);
 
     for (String codec : codecs) {
       String filename = generateTestFile(


### PR DESCRIPTION
commons-compress defaults to a 32K buffer size for Snappy.

However, Avro uses xerial.snappy to write, which has a 64K buffer size.
When the buffer size is too small, decoding data from Snappy can cause
an EOF exception rather than finishing data.

This fixes BEAM-422.