### PR TITLE
Closes #313. User friendly message for tempLocation

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -492,6 +492,22 @@ public class BigQueryIO {
         if (validate) {
           BigQueryOptions bqOptions = input.getPipeline().getOptions().as(BigQueryOptions.class);
 
+          String tempLocation = bqOptions.getTempLocation();
+          checkArgument(
+              !Strings.isNullOrEmpty(tempLocation),
+              "BigQueryIO.Read needs a GCS temp location to store temp files.");
+          if (testBigQueryServices == null) {
+            try {
+              GcsPath.fromUri(tempLocation);
+            } catch (IllegalArgumentException e) {
+              throw new IllegalArgumentException(
+                  String.format(
+                      "BigQuery temp location expected a valid 'gs://' path, but was given '%s'",
+                      tempLocation),
+                  e);
+            }
+          }
+
           TableReference table = getTableWithDefaultProject(bqOptions);
           if (table == null && query == null) {
             throw new IllegalStateException(


### PR DESCRIPTION
Temporary location is needed for BigQueryIO, in case of cloud based
runners at least one of `staging` or `temp` locations is required, for
location runners such requirement is not enforced thus it is possible
to end up with nasty NPE - see #313. Provide more user friendly
exception, with suggestion to set `temp` location.