### PR TITLE
Check for existence of job before polling. Closes #330.

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -399,6 +399,10 @@ public class BigQueryIO {
       // We expect the jobs have already DONE, and don't need a high max retires.
       private static final int CLEANUP_JOB_POLL_MAX_RETRIES = 10;
 
+      // The job should either exist on not, that said we could expect some hiccups on the service
+      // side.
+      private static final int CLEANUP_JOB_EXISTENCE_MAX_RETRIES = 3;
+
       private Bound() {
         this(
             null /* name */,
@@ -600,8 +604,10 @@ public class BigQueryIO {
                 JobReference jobRef = new JobReference()
                     .setProjectId(executingProject)
                     .setJobId(getExtractJobId(jobIdToken));
-                Job extractJob = bqServices.getJobService(bqOptions).pollJob(
-                    jobRef, CLEANUP_JOB_POLL_MAX_RETRIES);
+
+                JobService jobService = bqServices.getJobService(bqOptions);
+
+                Job extractJob = jobService.getJob(jobRef, CLEANUP_JOB_EXISTENCE_MAX_RETRIES);
 
                 Collection<String> extractFiles = null;
                 if (extractJob != null) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
@@ -93,6 +93,13 @@ public interface BigQueryServices extends Serializable {
      */
     JobStatistics dryRunQuery(String projectId, String query)
         throws InterruptedException, IOException;
+
+    /**
+     * Gets the Job by {@link JobReference}.
+     *
+     * Returns null if the job is not found or if the {@code maxAttempts} retries reached.
+     */
+    Job getJob(JobReference jobRef, int maxAttempts) throws InterruptedException;
   }
 
   /**

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
@@ -325,6 +325,11 @@ public class BigQueryIOTest implements Serializable {
         throws InterruptedException, IOException {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Boolean exists(JobReference jobRef, int maxAttempts) throws InterruptedException {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Rule public transient ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
In case of local runners, export job does not exists, check if job
exists before polling for result. This will prevent unnecessary
exceptions, polling in local mode.