### PR TITLE
Clarify RequiresWindowAccess error message

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/DoFnRunnerBase.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/DoFnRunnerBase.java
@@ -434,7 +434,7 @@ public abstract class DoFnRunnerBase<InputT, OutputT> implements DoFnRunner<Inpu
     public BoundedWindow window() {
       if (!(fn instanceof RequiresWindowAccess)) {
         throw new UnsupportedOperationException(
-            "window() is only available in the context of a DoFn marked as RequiresWindow.");
+            "window() is only available in the context of a DoFn marked as RequiresWindowAccess.");
       }
       return Iterables.getOnlyElement(windows());
     }


### PR DESCRIPTION
An error message is printed when a DoFn needs access to the window but does
not implement RequiresWindowAccess. This PR changes to the error message
to print the interface name instead of just "RequiresWindow", which makes it
more clear which interface the user should use.