### PR TITLE
Merge pr 331, with some fixups

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -399,6 +399,10 @@ public class BigQueryIO {
       // We expect the jobs have already DONE, and don't need a high max retires.
       private static final int CLEANUP_JOB_POLL_MAX_RETRIES = 10;
 
+      // The job should either exist on not, that said we could expect some hiccups on the service
+      // side.
+      private static final int CLEANUP_JOB_EXISTENCE_MAX_RETRIES = 3;
+
       private Bound() {
         this(
             null /* name */,
@@ -600,8 +604,10 @@ public class BigQueryIO {
                 JobReference jobRef = new JobReference()
                     .setProjectId(executingProject)
                     .setJobId(getExtractJobId(jobIdToken));
-                Job extractJob = bqServices.getJobService(bqOptions).pollJob(
-                    jobRef, CLEANUP_JOB_POLL_MAX_RETRIES);
+
+                JobService jobService = bqServices.getJobService(bqOptions);
+
+                Job extractJob = jobService.getJob(jobRef, CLEANUP_JOB_EXISTENCE_MAX_RETRIES);
 
                 Collection<String> extractFiles = null;
                 if (extractJob != null) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -395,14 +395,6 @@ public class BigQueryIO {
           "Validation of query \"%1$s\" failed. If the query depends on an earlier stage of the"
           + " pipeline, This validation can be disabled using #withoutValidation.";
 
-      // The maximum number of retries to poll a BigQuery job in the cleanup phase.
-      // We expect the jobs have already DONE, and don't need a high max retires.
-      private static final int CLEANUP_JOB_POLL_MAX_RETRIES = 10;
-
-      // The job should either exist on not, that said we could expect some hiccups on the service
-      // side.
-      private static final int CLEANUP_JOB_EXISTENCE_MAX_RETRIES = 3;
-
       private Bound() {
         this(
             null /* name */,
@@ -605,9 +597,8 @@ public class BigQueryIO {
                     .setProjectId(executingProject)
                     .setJobId(getExtractJobId(jobIdToken));
 
-                JobService jobService = bqServices.getJobService(bqOptions);
-
-                Job extractJob = jobService.getJob(jobRef, CLEANUP_JOB_EXISTENCE_MAX_RETRIES);
+                Job extractJob = bqServices.getJobService(bqOptions)
+                    .getJob(jobRef);
 
                 Collection<String> extractFiles = null;
                 if (extractJob != null) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
@@ -95,11 +95,11 @@ public interface BigQueryServices extends Serializable {
         throws InterruptedException, IOException;
 
     /**
-     * Gets the Job by {@link JobReference}.
+     * Gets the specified {@link Job} by the given {@link JobReference}.
      *
-     * Returns null if the job is not found or if the {@code maxAttempts} retries reached.
+     * Returns null if the job is not found.
      */
-    Job getJob(JobReference jobRef, int maxAttempts) throws InterruptedException;
+    Job getJob(JobReference jobRef) throws IOException, InterruptedException;
   }
 
   /**

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
@@ -93,6 +93,13 @@ public interface BigQueryServices extends Serializable {
      */
     JobStatistics dryRunQuery(String projectId, String query)
         throws InterruptedException, IOException;
+
+    /**
+     * Gets the Job by {@link JobReference}.
+     *
+     * Returns null if the job is not found or if the {@code maxAttempts} retries reached.
+     */
+    Job getJob(JobReference jobRef, int maxAttempts) throws InterruptedException;
   }
 
   /**

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
@@ -210,17 +210,21 @@ public class BigQueryIOTest implements Serializable {
 
     private Object[] startJobReturns;
     private Object[] pollJobReturns;
+    private Object[] getJobReturns;
     private String executingProject;
     // Both counts will be reset back to zeros after serialization.
     // This is a work around for DoFn's verifyUnmodified check.
     private transient int startJobCallsCount;
     private transient int pollJobStatusCallsCount;
+    private transient int existsJobStatusCallsCount;
 
     public FakeJobService() {
       this.startJobReturns = new Object[0];
       this.pollJobReturns = new Object[0];
+      this.getJobReturns = new Object[0];
       this.startJobCallsCount = 0;
       this.pollJobStatusCallsCount = 0;
+      this.existsJobStatusCallsCount = 0;
     }
 
     /**
@@ -231,6 +235,16 @@ public class BigQueryIOTest implements Serializable {
      */
     public FakeJobService startJobReturns(Object... startJobReturns) {
       this.startJobReturns = startJobReturns;
+      return this;
+    }
+
+    /**
+     * Sets the return values to mock {@link JobService#getJob}.
+     *
+     * <p>Throws if the {@link Object} is a {@link InterruptedException}, returns otherwise.
+     */
+    public FakeJobService getJobReturns(Object... getJobReturns) {
+      this.getJobReturns = getJobReturns;
       return this;
     }
 
@@ -324,6 +338,32 @@ public class BigQueryIOTest implements Serializable {
     public JobStatistics dryRunQuery(String projectId, String query)
         throws InterruptedException, IOException {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Job getJob(JobReference jobRef, int maxAttempts) throws InterruptedException {
+      if (!Strings.isNullOrEmpty(executingProject)) {
+        checkArgument(
+            jobRef.getProjectId().equals(executingProject),
+            "Project id: %s is not equal to executing project: %s",
+            jobRef.getProjectId(), executingProject);
+      }
+
+      if (existsJobStatusCallsCount < getJobReturns.length) {
+        Object ret = getJobReturns[existsJobStatusCallsCount++];
+        if (ret == null) {
+          return null;
+        } else if (ret instanceof Boolean) {
+          return (Job) ret;
+        } else if (ret instanceof InterruptedException) {
+          throw (InterruptedException) ret;
+        } else {
+          throw new RuntimeException("Unexpected return type: " + ret.getClass());
+        }
+      } else {
+        throw new RuntimeException(
+            "Exceeded expected number of calls: " + getJobReturns.length);
+      }
     }
   }
 
@@ -518,7 +558,7 @@ public class BigQueryIOTest implements Serializable {
     FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
         .withJobService(new FakeJobService()
             .startJobReturns("done", "done")
-            .pollJobReturns(Status.UNKNOWN)
+            .getJobReturns((Job) null)
             .verifyExecutingProject(bqOptions.getProject()))
         .readerReturns(
             toJsonString(new TableRow().set("name", "a").set("number", 1)),
@@ -578,6 +618,41 @@ public class BigQueryIOTest implements Serializable {
       public boolean accept(File pathname) {
         return pathname.isFile();
       }}).length);
+  }
+
+  @Test
+  public void testExportJobDoesNotExist() throws Exception {
+    BigQueryOptions bqOptions = PipelineOptionsFactory.as(BigQueryOptions.class);
+    bqOptions.setProject("defaultProject");
+    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+
+    FakeJobService fakeJobService = new FakeJobService()
+        .getJobReturns((Job) null)
+        .verifyExecutingProject(bqOptions.getProject());
+
+    FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
+        .withJobService(fakeJobService)
+        .readerReturns(
+            toJsonString(new TableRow().set("name", "a").set("number", 1)),
+            toJsonString(new TableRow().set("name", "b").set("number", 2)),
+            toJsonString(new TableRow().set("name", "c").set("number", 3)));
+
+    Pipeline p = TestPipeline.create(bqOptions);
+    PCollection<String> output = p
+        .apply(BigQueryIO.Read.from("non-executing-project:somedataset.sometable")
+            .withTestServices(fakeBqServices)
+            .withoutValidation())
+        .apply(ParDo.of(new DoFn<TableRow, String>() {
+          @Override
+          public void processElement(ProcessContext c) throws Exception {
+            c.output((String) c.element().get("name"));
+          }
+        }));
+
+    DataflowAssert.that(output)
+        .containsInAnyOrder(ImmutableList.of("a", "b", "c"));
+
+    p.run();
   }
 
   @Test

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryServicesImplTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryServicesImplTest.java
@@ -309,7 +309,7 @@ public class BigQueryServicesImplTest {
         .setProjectId("projectId")
         .setJobId("jobId");
     thrown.expect(IOException.class);
-    thrown.expectMessage(String.format("Unable to find job: %s", jobRef));
+    thrown.expectMessage(String.format("Unable to find BigQuery job: %s", jobRef));
 
     jobService.getJob(jobRef, Sleeper.DEFAULT, BackOff.STOP_BACKOFF);
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryServicesImplTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryServicesImplTest.java
@@ -259,6 +259,62 @@ public class BigQueryServicesImplTest {
   }
 
   @Test
+  public void testGetJobSucceeds() throws Exception {
+    Job testJob = new Job();
+    testJob.setStatus(new JobStatus());
+
+    when(response.getContentType()).thenReturn(Json.MEDIA_TYPE);
+    when(response.getStatusCode()).thenReturn(200);
+    when(response.getContent()).thenReturn(toStream(testJob));
+
+    BigQueryServicesImpl.JobServiceImpl jobService =
+        new BigQueryServicesImpl.JobServiceImpl(bigquery);
+    JobReference jobRef = new JobReference()
+        .setProjectId("projectId")
+        .setJobId("jobId");
+    Job job = jobService.getJob(jobRef, Sleeper.DEFAULT, BackOff.ZERO_BACKOFF);
+
+    assertEquals(testJob, job);
+    verify(response, times(1)).getStatusCode();
+    verify(response, times(1)).getContent();
+    verify(response, times(1)).getContentType();
+  }
+
+  @Test
+  public void testGetJobNotFound() throws Exception {
+    when(response.getContentType()).thenReturn(Json.MEDIA_TYPE);
+    when(response.getStatusCode()).thenReturn(404);
+
+    BigQueryServicesImpl.JobServiceImpl jobService =
+        new BigQueryServicesImpl.JobServiceImpl(bigquery);
+    JobReference jobRef = new JobReference()
+        .setProjectId("projectId")
+        .setJobId("jobId");
+    Job job = jobService.getJob(jobRef, Sleeper.DEFAULT, BackOff.ZERO_BACKOFF);
+
+    assertEquals(null, job);
+    verify(response, times(1)).getStatusCode();
+    verify(response, times(1)).getContent();
+    verify(response, times(1)).getContentType();
+  }
+
+  @Test
+  public void testGetJobThrows() throws Exception {
+    when(response.getContentType()).thenReturn(Json.MEDIA_TYPE);
+    when(response.getStatusCode()).thenReturn(401);
+
+    BigQueryServicesImpl.JobServiceImpl jobService =
+        new BigQueryServicesImpl.JobServiceImpl(bigquery);
+    JobReference jobRef = new JobReference()
+        .setProjectId("projectId")
+        .setJobId("jobId");
+    thrown.expect(IOException.class);
+    thrown.expectMessage(String.format("Unable to find job: %s", jobRef));
+
+    jobService.getJob(jobRef, Sleeper.DEFAULT, BackOff.STOP_BACKOFF);
+  }
+
+  @Test
   public void testExecuteWithRetries() throws IOException, InterruptedException {
     Table testTable = new Table();
 


### PR DESCRIPTION
Additional fixups:
1. Uses the default MAX_RPC_ATTEMPTS, and reduced number of the parameters.
2. Uses errorExtractor
3. Removed testExportJobDoesNotExist, since it is same as testReadFromTable.
4. Adds getJob() unit tests.