### PR TITLE
Use Datastore AncestorKey for AutoComplete example

### DIFF
--- a/examples/src/main/java/com/google/cloud/dataflow/examples/complete/AutoComplete.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/complete/AutoComplete.java
@@ -62,7 +62,6 @@ import com.google.common.base.Preconditions;
 import com.google.datastore.v1beta3.Entity;
 import com.google.datastore.v1beta3.Key;
 import com.google.datastore.v1beta3.Value;
-import com.google.datastore.v1beta3.client.DatastoreHelper;
 
 import org.joda.time.Duration;
 

--- a/examples/src/main/java/com/google/cloud/dataflow/examples/complete/AutoComplete.java
+++ b/examples/src/main/java/com/google/cloud/dataflow/examples/complete/AutoComplete.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.dataflow.examples.complete;
 
+import static com.google.datastore.v1beta3.client.DatastoreHelper.makeKey;
 import static com.google.datastore.v1beta3.client.DatastoreHelper.makeValue;
 
 import com.google.api.services.bigquery.model.TableFieldSchema;
@@ -384,6 +385,10 @@ public class AutoComplete {
   /**
    * Takes as input a the top candidates per prefix, and emits an entity
    * suitable for writing to Datastore.
+   *
+   * <p>Note: We use ancestor keys for strong consistency. See the Cloud Datastore documentation on
+   * <a href="https://cloud.google.com/datastore/docs/concepts/structuring_for_strong_consistency">
+   * Structuring Data for Strong Consistency</a>
    */
   static class FormatForDatastore extends DoFn<KV<String, List<CompletionCandidate>>, Entity> {
     private String kind;
@@ -395,7 +400,8 @@ public class AutoComplete {
     @Override
     public void processElement(ProcessContext c) {
       Entity.Builder entityBuilder = Entity.newBuilder();
-      Key key = DatastoreHelper.makeKey(kind, c.element().getKey()).build();
+      Key ancestoryKey = makeKey(kind, "root").build();
+      Key key = makeKey(ancestoryKey, kind, c.element().getKey()).build();
 
       entityBuilder.setKey(key);
       List<Value> candidates = new ArrayList<>();


### PR DESCRIPTION
- To provide strongly consistent reads of entities written to Datastore, we need to use ancestor keys.