### PR TITLE
Minor nit on Datastore capitalization

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/coders/EntityCoder.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/coders/EntityCoder.java
@@ -78,7 +78,7 @@ public class EntityCoder extends AtomicCoder<Entity> {
    * {@inheritDoc}
    *
    * @throws NonDeterministicException always.
-   *         A datastore kind can hold arbitrary {@link Object} instances, which
+   *         A Datastore kind can hold arbitrary {@link Object} instances, which
    *         makes the encoding non-deterministic.
    */
   @Override


### PR DESCRIPTION
Prevents localization issues where the product name is translated by mistake to a local language.