### PR TITLE
Deduplicate Unbounded Reads

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadDeduplicator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadDeduplicator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import org.joda.time.Duration;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Provides methods to determine if a record is a duplicate within the evaluation of a
+ * {@link Unbounded} {@link PTransform}.
+ */
+interface UnboundedReadDeduplicator {
+  /**
+   * Returns true if the record with the provided ID should be output, and false if it should not
+   * be because it is a duplicate.
+   */
+  boolean shouldOutput(byte[] recordId);
+
+  /**
+   * An {@link UnboundedReadDeduplicator} that always returns true. For use with sources do not
+   * require deduplication.
+   */
+  class NeverDeduplicator implements UnboundedReadDeduplicator {
+    /**
+     * Create a new {@link NeverDeduplicator}.
+     */
+    public static UnboundedReadDeduplicator create() {
+      return new NeverDeduplicator();
+    }
+
+    @Override
+    public boolean shouldOutput(byte[] recordId) {
+      return true;
+    }
+  }
+
+
+  /**
+   * An {@link UnboundedReadDeduplicator} that returns true if the record ID has not been seen
+   * within 10 minutes.
+   */
+  class CachedIdDeduplicator implements UnboundedReadDeduplicator {
+    private static final ByteArrayCoder RECORD_ID_CODER = ByteArrayCoder.of();
+    private static final long MAX_RETENTION_SINCE_ACCESS =
+        Duration.standardMinutes(10L).getMillis();
+
+    private final LoadingCache<StructuralKey<byte[]>, AtomicBoolean> ids;
+
+    /**
+     * Create a new {@link CachedIdDeduplicator}.
+     */
+    public static UnboundedReadDeduplicator create() {
+      return new CachedIdDeduplicator();
+    }
+
+    private CachedIdDeduplicator() {
+      ids = CacheBuilder.newBuilder()
+          .expireAfterAccess(MAX_RETENTION_SINCE_ACCESS, TimeUnit.MILLISECONDS)
+          .maximumSize(100_000L)
+          .build(new TrueBooleanLoader());
+    }
+
+    @Override
+    public boolean shouldOutput(byte[] recordId) {
+      return ids.getUnchecked(StructuralKey.of(recordId, RECORD_ID_CODER)).getAndSet(false);
+    }
+
+    private static class TrueBooleanLoader
+        extends CacheLoader<StructuralKey<byte[]>, AtomicBoolean> {
+      @Override
+      public AtomicBoolean load(StructuralKey<byte[]> key) throws Exception {
+        return new AtomicBoolean(true);
+      }
+    }
+  }
+
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadDeduplicatorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadDeduplicatorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.runners.inprocess.UnboundedReadDeduplicator.CachedIdDeduplicator;
+import com.google.cloud.dataflow.sdk.runners.inprocess.UnboundedReadDeduplicator.NeverDeduplicator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for {@link UnboundedReadDeduplicator}.
+ */
+@RunWith(JUnit4.class)
+public class UnboundedReadDeduplicatorTest {
+  @Test
+  public void neverDeduplicatorAlwaysTrue() {
+    byte[] id = new byte[] {-1, 2, 4, 22};
+    UnboundedReadDeduplicator dedupper = NeverDeduplicator.create();
+
+    assertThat(dedupper.shouldOutput(id), is(true));
+    assertThat(dedupper.shouldOutput(id), is(true));
+  }
+
+  @Test
+  public void cachedIdDeduplicatorTrueForFirstIdThenFalse() {
+    byte[] id = new byte[] {-1, 2, 4, 22};
+    UnboundedReadDeduplicator dedupper = CachedIdDeduplicator.create();
+
+    assertThat(dedupper.shouldOutput(id), is(true));
+    assertThat(dedupper.shouldOutput(id), is(false));
+  }
+
+  @Test
+  public void cachedIdDeduplicatorMultithreaded() throws InterruptedException {
+    byte[] id = new byte[] {-1, 2, 4, 22};
+    UnboundedReadDeduplicator dedupper = CachedIdDeduplicator.create();
+    final CountDownLatch startSignal = new CountDownLatch(1);
+    int numThreads = 1000;
+    final CountDownLatch readyLatch = new CountDownLatch(numThreads);
+    final CountDownLatch finishLine = new CountDownLatch(numThreads);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    AtomicInteger successCount = new AtomicInteger();
+    AtomicInteger failureCount = new AtomicInteger();
+    for (int i = 0; i < numThreads; i++) {
+      executor.submit(new TryOutputIdRunnable(dedupper,
+          id,
+          successCount,
+          failureCount,
+          readyLatch,
+          startSignal,
+          finishLine));
+    }
+
+    readyLatch.await();
+    startSignal.countDown();
+    finishLine.await(10L, TimeUnit.SECONDS);
+    executor.shutdownNow();
+
+    assertThat(successCount.get(), equalTo(1));
+    assertThat(failureCount.get(), equalTo(numThreads - 1));
+  }
+
+  private static class TryOutputIdRunnable implements Runnable {
+    private final UnboundedReadDeduplicator deduplicator;
+    private final byte[] id;
+    private final AtomicInteger successCount;
+    private final AtomicInteger failureCount;
+    private final CountDownLatch readyLatch;
+    private final CountDownLatch startSignal;
+    private final CountDownLatch finishLine;
+
+    public TryOutputIdRunnable(
+        UnboundedReadDeduplicator dedupper,
+        byte[] id,
+        AtomicInteger successCount,
+        AtomicInteger failureCount,
+        CountDownLatch readyLatch,
+        CountDownLatch startSignal,
+        CountDownLatch finishLine) {
+      this.deduplicator = dedupper;
+      this.id = id;
+      this.successCount = successCount;
+      this.failureCount = failureCount;
+      this.readyLatch = readyLatch;
+      this.startSignal = startSignal;
+      this.finishLine = finishLine;
+    }
+
+    @Override
+    public void run() {
+      readyLatch.countDown();
+      try {
+        startSignal.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      if (deduplicator.shouldOutput(id)) {
+        successCount.incrementAndGet();
+      } else {
+        failureCount.incrementAndGet();
+      }
+      finishLine.countDown();
+    }
+  }
+}


### PR DESCRIPTION
This ensures that sources that produce duplicate elements that are
marked as requiresDeduplication are handled by the DirectRunner.

Backports https://github.com/apache/incubator-beam/pull/473