### PR TITLE
Remove unneccessary method in ReadEvaluatorFactories

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/UnboundedReadEvaluatorFactory.java
@@ -32,7 +32,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.joda.time.Instant;
 
 import java.io.IOException;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -70,24 +69,17 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
     return getTransformEvaluator((AppliedPTransform) application, evaluationContext);
   }
 
-  private <OutputT> TransformEvaluator<?> getTransformEvaluator(
-      final AppliedPTransform<?, PCollection<OutputT>, Unbounded<OutputT>> transform,
-      final InProcessEvaluationContext evaluationContext) {
-    return getTransformEvaluatorQueue(transform, evaluationContext).poll();
-  }
-
   /**
-   * Get the queue of {@link TransformEvaluator TransformEvaluators} that produce elements for the
-   * provided application of {@link Unbounded Read.Unbounded}, initializing it if required.
+   * Get a {@link TransformEvaluator} that produce elements for the provided application of
+   * {@link Unbounded Read.Unbounded}, initializing the queue of evaluators if required.
    *
    * <p>This method is thread-safe, and will only produce new evaluators if no other invocation has
    * already done so.
    */
-  @SuppressWarnings("unchecked")
   private <OutputT, CheckpointMarkT extends CheckpointMark>
-  Queue<UnboundedReadEvaluator<OutputT, CheckpointMarkT>> getTransformEvaluatorQueue(
-      final AppliedPTransform<?, PCollection<OutputT>, Unbounded<OutputT>> transform,
-      final InProcessEvaluationContext evaluationContext) {
+      TransformEvaluator<?> getTransformEvaluator(
+          final AppliedPTransform<?, PCollection<OutputT>, Unbounded<OutputT>> transform,
+          final InProcessEvaluationContext evaluationContext) {
     // Key by the application and the context the evaluation is occurring in (which call to
     // Pipeline#run).
     EvaluatorKey key = new EvaluatorKey(transform, evaluationContext);
@@ -113,7 +105,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
                 sourceEvaluators.get(key);
       }
     }
-    return evaluatorQueue;
+    return evaluatorQueue.poll();
   }
 
   /**


### PR DESCRIPTION
The getTransformEvaluator() method's only call is poll on the result of
getTransformEvaluatorQueue (which is only ever called by
getTransformEvaluator). Instead, move the construction to
getTransformEvaluator and call poll on the result.

Backports https://github.com/apache/incubator-beam/pull/747