### PR TITLE
Make TimerData#compareTo consistent with equals

### DIFF
--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/TimerInternalsTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/TimerInternalsTest.java
@@ -15,12 +15,18 @@
  */
 package com.google.cloud.dataflow.sdk.util;
 
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
 import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.testing.CoderProperties;
 import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindow;
 import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
 import com.google.cloud.dataflow.sdk.util.TimerInternals.TimerData;
 import com.google.cloud.dataflow.sdk.util.TimerInternals.TimerDataCoder;
+import com.google.cloud.dataflow.sdk.util.state.StateNamespace;
 import com.google.cloud.dataflow.sdk.util.state.StateNamespaces;
 
 import org.joda.time.Instant;
@@ -47,6 +53,47 @@ public class TimerInternalsTest {
             StateNamespaces.window(
                 windowCoder, new IntervalWindow(new Instant(0), new Instant(100))),
             new Instant(99), TimeDomain.PROCESSING_TIME));
+  }
+
+  @Test
+  public void testCompareTo() {
+    Instant firstTimestamp = new Instant(100);
+    Instant secondTimestamp = new Instant(200);
+    IntervalWindow firstWindow = new IntervalWindow(new Instant(0), firstTimestamp);
+    IntervalWindow secondWindow = new IntervalWindow(firstTimestamp, secondTimestamp);
+    Coder<IntervalWindow> windowCoder = IntervalWindow.getCoder();
+
+    StateNamespace firstWindowNs = StateNamespaces.window(windowCoder, firstWindow);
+    StateNamespace secondWindowNs = StateNamespaces.window(windowCoder, secondWindow);
+
+    TimerData firstEventTime = TimerData.of(firstWindowNs, firstTimestamp, TimeDomain.EVENT_TIME);
+    TimerData secondEventTime = TimerData.of(firstWindowNs, secondTimestamp, TimeDomain.EVENT_TIME);
+    TimerData thirdEventTime = TimerData.of(secondWindowNs, secondTimestamp, TimeDomain.EVENT_TIME);
+
+    TimerData firstProcTime =
+        TimerData.of(firstWindowNs, firstTimestamp, TimeDomain.PROCESSING_TIME);
+    TimerData secondProcTime =
+        TimerData.of(firstWindowNs, secondTimestamp, TimeDomain.PROCESSING_TIME);
+    TimerData thirdProcTime =
+        TimerData.of(secondWindowNs, secondTimestamp, TimeDomain.PROCESSING_TIME);
+
+    assertThat(firstEventTime,
+        comparesEqualTo(TimerData.of(firstWindowNs, firstTimestamp, TimeDomain.EVENT_TIME)));
+    assertThat(firstEventTime, lessThan(secondEventTime));
+    assertThat(secondEventTime, lessThan(thirdEventTime));
+    assertThat(firstEventTime, lessThan(thirdEventTime));
+
+    assertThat(secondProcTime,
+        comparesEqualTo(TimerData.of(firstWindowNs, secondTimestamp, TimeDomain.PROCESSING_TIME)));
+    assertThat(firstProcTime, lessThan(secondProcTime));
+    assertThat(secondProcTime, lessThan(thirdProcTime));
+    assertThat(firstProcTime, lessThan(thirdProcTime));
+
+    assertThat(firstEventTime, not(comparesEqualTo(firstProcTime)));
+    assertThat(firstProcTime,
+        not(comparesEqualTo(TimerData.of(firstWindowNs,
+            firstTimestamp,
+            TimeDomain.SYNCHRONIZED_PROCESSING_TIME))));
   }
 }
 


### PR DESCRIPTION
Timers are equal if the domain, timestamp, and namespace are equal.
Compare these values in compareTo. The ordering of TimerData that are
not in the same namespace or domain is arbitrary.

Update GroupAlsoByWindowsProperties to ignore ordering of output
values, as this is not part of the requirements of a GroupAlsoByWindows
implementation.

in part backports https://github.com/apache/incubator-beam/pull/813
Requires review for GroupAlsoByWindowsProperties update.