### PR TITLE
Upgrade grpc-java lib to pre GA version, not to mock stub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <!-- If updating dependencies, please update any relevant javadoc offlineLinks -->
     <avro.version>1.7.7</avro.version>
     <bigquery.version>v2-rev295-1.22.0</bigquery.version>
-    <pubsubgrpc.version>0.0.2</pubsubgrpc.version>
+    <pubsubgrpc.version>0.0.7</pubsubgrpc.version>
     <bigtable.version>0.3.0</bigtable.version>
     <clouddebugger.version>v2-rev8-1.22.0</clouddebugger.version>
     <dataflow.version>v1b3-rev30-1.22.0</dataflow.version>
@@ -79,7 +79,7 @@
     <datastore.client.version>1.0.0-beta.2</datastore.client.version>
     <datastore.proto.version>1.0.0-beta</datastore.proto.version>
     <google-clients.version>1.22.0</google-clients.version>
-    <grpc.version>0.13.1</grpc.version>
+    <grpc.version>0.15.0</grpc.version>
     <guava.version>19.0</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson.version>2.7.0</jackson.version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -482,19 +482,38 @@
 
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-all</artifactId>
+      <artifactId>grpc-auth</artifactId>
       <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>4.1.0.CR1</version>
+      <version>4.1.1.Final</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-pubsub-v1</artifactId>
+      <artifactId>grpc-google-pubsub-v1</artifactId>
       <version>${pubsubgrpc.version}</version>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled in by a transitive


### PR DESCRIPTION
---Release Notes---
Migrate gRPC-java lib to pre GA release version.
For .proto generated java code in gRPC-java version 0.15.0, GA and
above:
- Interfaces for the stubs are no longer generated
- Stubs become final classes and should not be mocked by mockito.
    Please be referred to the docs:
    https://docs.google.com/presentation/d/1x8KaWbOIcT03Ct0XdfaQlcmiory4eNSvkkC5dBWCt6I

----Internal Notes----
Migrating gRPC-java lib to pre GA release version across google3.