### PR TITLE
Exclude guava-testlib from shading relocation

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -360,6 +360,7 @@
                 <relocation>
                   <pattern>com.google.common</pattern>
                   <excludes>
+                    <!-- com.google.common is too generic, need to exclude guava-testlib -->
                     <exclude>com.google.common.**.testing</exclude>
                   </excludes>
                   <shadedPattern>com.google.cloud.dataflow.sdk.repackaged.com.google.common</shadedPattern>
@@ -781,6 +782,8 @@
     </dependency>
 
     <dependency>
+      <!-- Note: when package relocating guava, ensure guava-testlib is not
+           also relocated by excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>${guava.version}</version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -782,7 +782,7 @@
     </dependency>
 
     <dependency>
-      <!-- Note: when package relocating guava, ensure guava-testlib is not
+      <!-- Note: when relocating guava, ensure guava-testlib is not
            also relocated by excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -359,6 +359,9 @@
                      the second relocation. -->
                 <relocation>
                   <pattern>com.google.common</pattern>
+                  <excludes>
+                    <exclude>com.google.common.**.testing</exclude>
+                  </excludes>
                   <shadedPattern>com.google.cloud.dataflow.sdk.repackaged.com.google.common</shadedPattern>
                 </relocation>
                 <relocation>


### PR DESCRIPTION
Previously, guava-testlib guava-testlib was being relocated as part of
the shading process, but test-scope dependencies aren't bundled in the
uber-jar. As a result, the output JAR was unusable without recreating
the same shading rules in a consuming project.