### PR TITLE
ByteKeyRangeTracker: synchronize toString

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/range/ByteKeyRangeTracker.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/range/ByteKeyRangeTracker.java
@@ -175,7 +175,7 @@ public final class ByteKeyRangeTracker implements RangeTracker<ByteKey> {
   }
 
   @Override
-  public String toString() {
+  public synchronized String toString() {
     return toStringHelper(ByteKeyRangeTracker.class)
         .add("range", range)
         .add("position", position)


### PR DESCRIPTION
It's the only unsynchronized function, and it could potentially produce bad data.