### PR TITLE
Backport Beam PR-835 "Fix NPE in BigQueryIO.TransformingReader when it contains an unsplittable reader."

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -1146,9 +1146,9 @@ public class BigQueryIO {
         BoundedSource<T> boundedSource,
         SerializableFunction<T, V> function,
         Coder<V> outputCoder) {
-      this.boundedSource = boundedSource;
-      this.function = function;
-      this.outputCoder = outputCoder;
+      this.boundedSource = checkNotNull(boundedSource, "boundedSource");
+      this.function = checkNotNull(function, "function");
+      this.outputCoder = checkNotNull(outputCoder, "outputCoder");
     }
 
     @Override
@@ -1193,7 +1193,7 @@ public class BigQueryIO {
       private final BoundedReader<T> boundedReader;
 
       private TransformingReader(BoundedReader<T> boundedReader) {
-        this.boundedReader = boundedReader;
+        this.boundedReader = checkNotNull(boundedReader, "boundedReader");
       }
 
       @Override
@@ -1224,8 +1224,8 @@ public class BigQueryIO {
 
       @Override
       public synchronized BoundedSource<V> splitAtFraction(double fraction) {
-        return new TransformingSource<>(
-            boundedReader.splitAtFraction(fraction), function, outputCoder);
+        BoundedSource<T> split = boundedReader.splitAtFraction(fraction);
+        return split == null ? null : new TransformingSource<>(split, function, outputCoder);
       }
 
       @Override

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/SourceTestUtils.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/SourceTestUtils.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.dataflow.sdk.testing;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -28,8 +30,11 @@ import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.io.BoundedSource;
 import com.google.cloud.dataflow.sdk.io.Source;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
 import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.ImmutableList;
 
+import org.joda.time.Instant;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,12 +42,15 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import javax.annotation.Nullable;
 
 /**
  * Helper functions and test harnesses for checking correctness of {@link Source}
@@ -671,5 +679,127 @@ public class SourceTestUtils {
         source, expectedItems, currentItems, splitSources.getKey(), splitSources.getValue(),
         numItemsToReadBeforeSplitting, fraction, options);
     return (res.numResidualItems > 0);
+  }
+
+  /**
+   * Returns an equivalent unsplittable {@code BoundedSource<T>}.
+   *
+   * <p>It forwards most methods to the given {@code boundedSource}, except:
+   * <ol>
+   * <li> {@link BoundedSource#splitIntoBundles} rejects initial splitting
+   * by returning itself in a list.
+   * <li> {@link BoundedReader#splitAtFraction} rejects dynamic splitting by returning null.
+   * </ol>
+   */
+  public static <T> BoundedSource<T> toUnsplittableSource(BoundedSource<T> boundedSource) {
+    return new UnsplittableSource<>(boundedSource);
+  }
+
+  private static class UnsplittableSource<T> extends BoundedSource<T> {
+
+    private final BoundedSource<T> boundedSource;
+
+    private UnsplittableSource(BoundedSource<T> boundedSource) {
+      this.boundedSource = checkNotNull(boundedSource, "boundedSource");
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      this.boundedSource.populateDisplayData(builder);
+    }
+
+    @Override
+    public List<? extends BoundedSource<T>> splitIntoBundles(
+        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
+      return ImmutableList.of(this);
+    }
+
+    @Override
+    public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
+      return boundedSource.getEstimatedSizeBytes(options);
+    }
+
+    @Override
+    public boolean producesSortedKeys(PipelineOptions options) throws Exception {
+      return boundedSource.producesSortedKeys(options);
+    }
+
+    @Override
+    public BoundedReader<T> createReader(PipelineOptions options) throws IOException {
+      return new UnsplittableReader<>(boundedSource, boundedSource.createReader(options));
+    }
+
+    @Override
+    public void validate() {
+      boundedSource.validate();
+    }
+
+    @Override
+    public Coder<T> getDefaultOutputCoder() {
+      return boundedSource.getDefaultOutputCoder();
+    }
+
+    private static class UnsplittableReader<T> extends BoundedReader<T> {
+
+      private final BoundedSource<T> boundedSource;
+      private final BoundedReader<T> boundedReader;
+
+      private UnsplittableReader(BoundedSource<T> boundedSource, BoundedReader<T> boundedReader) {
+        this.boundedSource = checkNotNull(boundedSource, "boundedSource");
+        this.boundedReader = checkNotNull(boundedReader, "boundedReader");
+      }
+
+      @Override
+      public BoundedSource<T> getCurrentSource() {
+        return boundedSource;
+      }
+
+      @Override
+      public boolean start() throws IOException {
+        return boundedReader.start();
+      }
+
+      @Override
+      public boolean advance() throws IOException {
+        return boundedReader.advance();
+      }
+
+      @Override
+      public T getCurrent() throws NoSuchElementException {
+        return boundedReader.getCurrent();
+      }
+
+      @Override
+      public void close() throws IOException {
+        boundedReader.close();
+      }
+
+      @Override
+      @Nullable
+      public BoundedSource<T> splitAtFraction(double fraction) {
+        return null;
+      }
+
+      @Override
+      @Nullable
+      public Double getFractionConsumed() {
+        return boundedReader.getFractionConsumed();
+      }
+
+      @Override
+      public long getSplitPointsConsumed() {
+        return boundedReader.getSplitPointsConsumed();
+      }
+
+      @Override
+      public long getSplitPointsRemaining() {
+        return boundedReader.getSplitPointsRemaining();
+      }
+
+      @Override
+      public Instant getCurrentTimestamp() throws NoSuchElementException {
+        return boundedReader.getCurrentTimestamp();
+      }
+    }
   }
 }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
@@ -1202,6 +1202,37 @@ public class BigQueryIOTest implements Serializable {
   }
 
   @Test
+  public void testTransformingSourceUnsplittable() throws Exception {
+    int numElements = 10000;
+    @SuppressWarnings("deprecation")
+    BoundedSource<Long> longSource =
+        SourceTestUtils.toUnsplittableSource(CountingSource.upTo(numElements));
+    SerializableFunction<Long, String> toStringFn =
+        new SerializableFunction<Long, String>() {
+          @Override
+          public String apply(Long input) {
+            return input.toString();
+          }
+        };
+    BoundedSource<String> stringSource =
+        new TransformingSource<>(longSource, toStringFn, StringUtf8Coder.of());
+
+    List<String> expected = Lists.newArrayList();
+    for (int i = 0; i < numElements; i++) {
+      expected.add(String.valueOf(i));
+    }
+
+    PipelineOptions options = PipelineOptionsFactory.create();
+    Assert.assertThat(
+        SourceTestUtils.readFromSource(stringSource, options), CoreMatchers.is(expected));
+    SourceTestUtils.assertSplitAtFractionBehavior(
+        stringSource, 100, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
+
+    SourceTestUtils.assertSourcesEqualReferenceSource(
+        stringSource, stringSource.splitIntoBundles(100, options), options);
+  }
+
+  @Test
   @Category(RunnableOnService.class)
   public void testPassThroughThenCleanup() throws Exception {
     Pipeline p = TestPipeline.create();

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/SourceTestUtilsTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/SourceTestUtilsTest.java
@@ -1,0 +1,64 @@
+
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.testing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.cloud.dataflow.sdk.io.BoundedSource;
+import com.google.cloud.dataflow.sdk.io.BoundedSource.BoundedReader;
+import com.google.cloud.dataflow.sdk.io.CountingSource;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.common.collect.Sets;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Tests for {@link SourceTestUtils}.
+ */
+@RunWith(JUnit4.class)
+public class SourceTestUtilsTest {
+
+  @Test
+  public void testToUnsplittableSource() throws Exception {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    BoundedSource<Long> baseSource = CountingSource.upTo(100);
+    BoundedSource<Long> unsplittableSource = SourceTestUtils.toUnsplittableSource(baseSource);
+    List<?> splits = unsplittableSource.splitIntoBundles(1, options);
+    assertEquals(splits.size(), 1);
+    assertEquals(splits.get(0), unsplittableSource);
+
+    BoundedReader<Long> unsplittableReader = unsplittableSource.createReader(options);
+    assertEquals(0, unsplittableReader.getFractionConsumed(), 1e-15);
+
+    Set<Long> expected = Sets.newHashSet(SourceTestUtils.readFromSource(baseSource, options));
+    Set<Long> actual = Sets.newHashSet();
+    actual.addAll(SourceTestUtils.readNItemsFromUnstartedReader(unsplittableReader, 40));
+    assertNull(unsplittableReader.splitAtFraction(0.5));
+    actual.addAll(SourceTestUtils.readRemainingFromReader(unsplittableReader, true /* started */));
+    assertEquals(1, unsplittableReader.getFractionConsumed(), 1e-15);
+
+    assertEquals(100, actual.size());
+    assertEquals(Sets.newHashSet(expected), Sets.newHashSet(actual));
+  }
+}


### PR DESCRIPTION
Backport https://github.com/apache/incubator-beam/pull/835/