### PR TITLE
Backport Beam changes to PAssert

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/DataflowAssert.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/DataflowAssert.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.dataflow.sdk.testing;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -27,51 +28,53 @@ import com.google.cloud.dataflow.sdk.coders.CoderException;
 import com.google.cloud.dataflow.sdk.coders.IterableCoder;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
 import com.google.cloud.dataflow.sdk.coders.MapCoder;
-import com.google.cloud.dataflow.sdk.coders.VoidCoder;
+import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
 import com.google.cloud.dataflow.sdk.options.StreamingOptions;
 import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
 import com.google.cloud.dataflow.sdk.transforms.Aggregator;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.Flatten;
+import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import com.google.cloud.dataflow.sdk.transforms.Sum;
 import com.google.cloud.dataflow.sdk.transforms.View;
+import com.google.cloud.dataflow.sdk.transforms.WithKeys;
 import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindows;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Never;
 import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window.Bound;
 import com.google.cloud.dataflow.sdk.util.CoderUtils;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PBegin;
 import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PCollectionList;
 import com.google.cloud.dataflow.sdk.values.PCollectionView;
 import com.google.cloud.dataflow.sdk.values.PDone;
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
 /**
- * An assertion on the contents of a {@link PCollection}
- * incorporated into the pipeline.  Such an assertion
- * can be checked no matter what kind of {@link PipelineRunner} is
- * used.
+ * An assertion on the contents of a {@link PCollection} incorporated into the pipeline. Such an
+ * assertion can be checked no matter what kind of {@link PipelineRunner} is used.
  *
  * <p>Note that the {@code DataflowAssert} call must precede the call
  * to {@link Pipeline#run}.
  *
- * <p>Examples of use:
- * <pre>{@code
+ * <p>Examples of use: <pre>{@code
  * Pipeline p = TestPipeline.create();
  * ...
  * PCollection<String> output =
@@ -101,34 +104,139 @@ public class DataflowAssert {
 
   private static int assertCount = 0;
 
+  private static String nextAssertionName() {
+    return "DataflowAssert$" + (assertCount++);
+  }
+
   // Do not instantiate.
   private DataflowAssert() {}
 
   /**
-   * Constructs an {@link IterableAssert} for the elements of the provided
-   * {@link PCollection}.
+   * Builder interface for assertions applicable to iterables and PCollection contents.
    */
-  public static <T> IterableAssert<T> that(PCollection<T> actual) {
-    return new IterableAssert<>(
-        new CreateActual<T, Iterable<T>>(actual, View.<T>asIterable()),
-         actual.getPipeline())
-         .setCoder(actual.getCoder());
+  public interface IterableAssert<T> {
+    /**
+     * Sets the coder of the actual {@link PCollection}.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     * @deprecated instead call {@link PCollection#setCoder(Coder)} on the actual
+     * {@link PCollection} directly.
+     */
+    @Deprecated
+    IterableAssert<T> setCoder(Coder<T> coderOrNull);
+
+    /**
+     * Returns the coder of the actual {@link PCollection}.
+     *
+     * @deprecated instead call {@link PCollection#getCoder()} on the actual {@link PCollection}
+     * directly
+     */
+    @Deprecated
+    Coder<T> getCoder();
+
+    /**
+     * Asserts that the iterable in question contains the provided elements.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> containsInAnyOrder(T... expectedElements);
+
+    /**
+     * Asserts that the iterable in question contains the provided elements.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements);
+
+    /**
+     * Asserts that the iterable in question is empty.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> empty();
+
+    /**
+     * Applies the provided checking function (presumably containing assertions) to the
+     * iterable in question.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> satisfies(SerializableFunction<Iterable<T>, Void> checkerFn);
   }
 
   /**
-   * Constructs an {@link IterableAssert} for the value of the provided
-   * {@link PCollection} which must contain a single {@code Iterable<T>}
-   * value.
+   * Builder interface for assertions applicable to a single value.
    */
-  public static <T> IterableAssert<T>
-      thatSingletonIterable(PCollection<? extends Iterable<T>> actual) {
+  public interface SingletonAssert<T> {
+    /**
+     * Sets the coder of the actual {@link PCollection}.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     * @deprecated instead call {@link PCollection#setCoder(Coder)} on the actual
+     * {@link PCollection} directly.
+     */
+    @Deprecated
+    SingletonAssert<T> setCoder(Coder<T> coderOrNull);
 
-    List<? extends Coder<?>> maybeElementCoder = actual.getCoder().getCoderArguments();
-    Coder<T> tCoder;
+    /**
+     * Returns the coder of the actual {@link PCollection}.
+     *
+     * @deprecated instead call {@link PCollection#getCoder()} on the actual {@link PCollection}
+     * directly
+     */
+    @Deprecated
+    Coder<T> getCoder();
+
+    /**
+     * Asserts that the value in question is equal to the provided value, according to
+     * {@link Object#equals}.
+     *
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    SingletonAssert<T> isEqualTo(T expected);
+
+    /**
+     * Asserts that the value in question is equal to the provided value, according to
+     * {@link Object#equals}.
+     *
+     * @deprecated instead use {@link #isEqualTo(Object)}
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    @Deprecated
+    SingletonAssert<T> is(T expected);
+
+    /**
+     * Asserts that the value in question is not equal to the provided value, according
+     * to {@link Object#equals}.
+     *
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    SingletonAssert<T> notEqualTo(T notExpected);
+
+    /**
+     * Applies the provided checking function (presumably containing assertions) to the
+     * value in question.
+     *
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    SingletonAssert<T> satisfies(SerializableFunction<T, Void> checkerFn);
+  }
+
+  /**
+   * Constructs an {@link IterableAssert} for the elements of the provided {@link PCollection}.
+   */
+  public static <T> IterableAssert<T> that(PCollection<T> actual) {
+    return new PCollectionContentsAssert<>(actual);
+  }
+
+  /**
+   * Constructs an {@link IterableAssert} for the value of the provided {@link PCollection} which
+   * must contain a single {@code Iterable<T>} value.
+   */
+  public static <T> IterableAssert<T> thatSingletonIterable(
+      PCollection<? extends Iterable<T>> actual) {
+
     try {
-      @SuppressWarnings("unchecked")
-      Coder<T> tCoderTmp = (Coder<T>) Iterables.getOnlyElement(maybeElementCoder);
-      tCoder = tCoderTmp;
     } catch (NoSuchElementException | IllegalArgumentException exc) {
       throw new IllegalArgumentException(
         "DataflowAssert.<T>thatSingletonIterable requires a PCollection<Iterable<T>>"
@@ -139,19 +247,16 @@ public class DataflowAssert {
     @SuppressWarnings("unchecked") // Safe covariant cast
     PCollection<Iterable<T>> actualIterables = (PCollection<Iterable<T>>) actual;
 
-    return new IterableAssert<>(
-        new CreateActual<Iterable<T>, Iterable<T>>(
-            actualIterables, View.<Iterable<T>>asSingleton()),
-        actual.getPipeline())
-        .setCoder(tCoder);
+    return new PCollectionSingletonIterableAssert<>(actualIterables);
   }
 
   /**
-   * Constructs an {@link IterableAssert} for the value of the provided
-   * {@code PCollectionView PCollectionView<Iterable<T>>}.
+   * Constructs an {@link IterableAssert} for the value of the provided {@link PCollectionView}.
    */
+  @Deprecated
   public static <T> IterableAssert<T> thatIterable(PCollectionView<Iterable<T>> actual) {
-    return new IterableAssert<>(new PreExisting<Iterable<T>>(actual), actual.getPipeline());
+    // TODO Before PR complete. Required for backwards compatibility purposes.
+    return null;
   }
 
   /**
@@ -159,81 +264,109 @@ public class DataflowAssert {
    * {@code PCollection PCollection<T>}, which must be a singleton.
    */
   public static <T> SingletonAssert<T> thatSingleton(PCollection<T> actual) {
-    return new SingletonAssert<>(
-        new CreateActual<T, T>(actual, View.<T>asSingleton()), actual.getPipeline())
-        .setCoder(actual.getCoder());
+    return new PCollectionViewAssert<>(actual, View.<T>asSingleton(), actual.getCoder());
   }
 
   /**
    * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection}.
    *
-   * <p>Note that the actual value must be coded by a {@link KvCoder},
-   * not just any {@code Coder<K, V>}.
+   * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
+   * {@code Coder<K, V>}.
    */
-  public static <K, V> SingletonAssert<Map<K, Iterable<V>>>
-      thatMultimap(PCollection<KV<K, V>> actual) {
+  public static <K, V> SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+      PCollection<KV<K, V>> actual) {
     @SuppressWarnings("unchecked")
     KvCoder<K, V> kvCoder = (KvCoder<K, V>) actual.getCoder();
-
-    return new SingletonAssert<>(
-        new CreateActual<>(actual, View.<K, V>asMultimap()), actual.getPipeline())
-        .setCoder(MapCoder.of(kvCoder.getKeyCoder(), IterableCoder.of(kvCoder.getValueCoder())));
+    return new PCollectionViewAssert<>(
+        actual,
+        View.<K, V>asMultimap(),
+        MapCoder.of(kvCoder.getKeyCoder(), IterableCoder.of(kvCoder.getValueCoder())));
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection},
-   * which must have at most one value per key.
+   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection}, which
+   * must have at most one value per key.
    *
-   * <p>Note that the actual value must be coded by a {@link KvCoder},
-   * not just any {@code Coder<K, V>}.
+   * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
+   * {@code Coder<K, V>}.
    */
   public static <K, V> SingletonAssert<Map<K, V>> thatMap(PCollection<KV<K, V>> actual) {
     @SuppressWarnings("unchecked")
     KvCoder<K, V> kvCoder = (KvCoder<K, V>) actual.getCoder();
-
-    return new SingletonAssert<>(
-        new CreateActual<>(actual, View.<K, V>asMap()), actual.getPipeline())
-        .setCoder(MapCoder.of(kvCoder.getKeyCoder(), kvCoder.getValueCoder()));
+    return new PCollectionViewAssert<>(
+        actual, View.<K, V>asMap(), MapCoder.of(kvCoder.getKeyCoder(), kvCoder.getValueCoder()));
   }
 
   ////////////////////////////////////////////////////////////
 
   /**
-   * An assertion about the contents of a {@link PCollectionView} yielding an {@code Iterable<T>}.
+   * An {@link IterableAssert} about the contents of a {@link PCollection}. This does not require
+   * the runner to support side inputs.
    */
-  public static class IterableAssert<T> implements Serializable {
-    private final Pipeline pipeline;
-    private final PTransform<PBegin, PCollectionView<Iterable<T>>> createActual;
-    private Optional<Coder<T>> coder;
+  private static class PCollectionContentsAssert<T> implements IterableAssert<T> {
+    private final PCollection<T> actual;
 
-    protected IterableAssert(
-        PTransform<PBegin, PCollectionView<Iterable<T>>> createActual, Pipeline pipeline) {
-      this.createActual = createActual;
-      this.pipeline = pipeline;
-      this.coder = Optional.absent();
+    public PCollectionContentsAssert(PCollection<T> actual) {
+      this.actual = actual;
     }
 
-    /**
-     * Sets the coder to use for elements of type {@code T}, as needed for internal purposes.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
+    @Override
     public IterableAssert<T> setCoder(Coder<T> coderOrNull) {
-      this.coder = Optional.fromNullable(coderOrNull);
-      return this;
-    }
-
-    /**
-     * Gets the coder, which may yet be absent.
-     */
-    public Coder<T> getCoder() {
-      if (coder.isPresent()) {
-        return coder.get();
-      } else {
-        throw new IllegalStateException(
-            "Attempting to access the coder of an IterableAssert"
-                + " that has not been set yet.");
+      if (coderOrNull != null) {
+        actual.setCoder(coderOrNull);
       }
+      return this;
+    }
+
+    @Override
+    public Coder<T> getCoder() {
+      return actual.getCoder();
+    }
+
+    /**
+     * Checks that the {@code Iterable} contains the expected elements, in any order.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    @Override
+    @SafeVarargs
+    public final PCollectionContentsAssert<T> containsInAnyOrder(T... expectedElements) {
+      return containsInAnyOrder(Arrays.asList(expectedElements));
+    }
+
+    /**
+     * Checks that the {@code Iterable} contains the expected elements, in any order.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    @Override
+    public PCollectionContentsAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
+      return satisfies(new AssertContainsInAnyOrderRelation<T>(), expectedElements);
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> empty() {
+      containsInAnyOrder(Collections.<T>emptyList());
+      return this;
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> satisfies(
+        SerializableFunction<Iterable<T>, Void> checkerFn) {
+      actual.apply(nextAssertionName(), new GroupThenAssert<>(checkerFn));
+      return this;
+    }
+
+    /**
+     * Checks that the {@code Iterable} contains elements that match the provided matchers, in any
+     * order.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    @SafeVarargs
+    final PCollectionContentsAssert<T> containsInAnyOrder(
+        SerializableMatcher<? super T>... elementMatchers) {
+      return satisfies(SerializableMatchers.<T>containsInAnyOrder(elementMatchers));
     }
 
     /**
@@ -241,28 +374,11 @@ public class DataflowAssert {
      *
      * <p>Returns this {@code IterableAssert}.
      */
-    public IterableAssert<T> satisfies(SerializableFunction<Iterable<T>, Void> checkerFn) {
-      pipeline.apply(
-          "DataflowAssert$" + (assertCount++),
-          new OneSideInputAssert<Iterable<T>>(createActual, checkerFn));
-      return this;
-    }
-
-    /**
-     * Applies a {@link SerializableFunction} to check the elements of the {@code Iterable}.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    public IterableAssert<T> satisfies(
-        AssertRelation<Iterable<T>, Iterable<T>> relation,
-        final Iterable<T> expectedElements) {
-      pipeline.apply(
-          "DataflowAssert$" + (assertCount++),
-          new TwoSideInputAssert<Iterable<T>, Iterable<T>>(createActual,
-              new CreateExpected<T, Iterable<T>>(expectedElements, coder, View.<T>asIterable()),
-              relation));
-
-      return this;
+    private PCollectionContentsAssert<T> satisfies(
+        AssertRelation<Iterable<T>, Iterable<T>> relation, Iterable<T> expectedElements) {
+      return satisfies(
+          new CheckRelationAgainstExpected<Iterable<T>>(
+              relation, expectedElements, IterableCoder.of(actual.getCoder())));
     }
 
     /**
@@ -270,17 +386,14 @@ public class DataflowAssert {
      *
      * <p>Returns this {@code IterableAssert}.
      */
-    IterableAssert<T> satisfies(final SerializableMatcher<Iterable<? extends T>> matcher) {
+    PCollectionContentsAssert<T> satisfies(
+        final SerializableMatcher<Iterable<? extends T>> matcher) {
       // Safe covariant cast. Could be elided by changing a lot of this file to use
       // more flexible bounds.
       @SuppressWarnings({"rawtypes", "unchecked"})
       SerializableFunction<Iterable<T>, Void> checkerFn =
-        (SerializableFunction) new MatcherCheckerFn<>(matcher);
-      pipeline.apply(
-          "DataflowAssert$" + (assertCount++),
-          new OneSideInputAssert<Iterable<T>>(
-              createActual,
-              checkerFn));
+          (SerializableFunction) new MatcherCheckerFn<>(matcher);
+      actual.apply("DataflowAssert$" + (assertCount++), new GroupThenAssert<>(checkerFn));
       return this;
     }
 
@@ -296,15 +409,6 @@ public class DataflowAssert {
         assertThat(actual, matcher);
         return null;
       }
-    }
-
-    /**
-     * Checks that the {@code Iterable} is empty.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    public IterableAssert<T> empty() {
-      return satisfies(new AssertContainsInAnyOrderRelation<T>(), Collections.<T>emptyList());
     }
 
     /**
@@ -330,57 +434,129 @@ public class DataflowAssert {
       throw new UnsupportedOperationException(
           String.format("%s.hashCode() is not supported.", IterableAssert.class.getSimpleName()));
     }
+  }
 
-    /**
-     * Checks that the {@code Iterable} contains the expected elements, in any
-     * order.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    public IterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
+  /**
+   * An {@link IterableAssert} for an iterable that is the sole element of a {@link PCollection}.
+   * This does not require the runner to support side inputs.
+   */
+  private static class PCollectionSingletonIterableAssert<T> implements IterableAssert<T> {
+    private final PCollection<Iterable<T>> actual;
+    private final Coder<T> elementCoder;
+
+    public PCollectionSingletonIterableAssert(PCollection<Iterable<T>> actual) {
+      this.actual = actual;
+
+      @SuppressWarnings("unchecked")
+      Coder<T> typedCoder = (Coder<T>) actual.getCoder().getCoderArguments().get(0);
+      this.elementCoder = typedCoder;
+    }
+
+    @Override
+    public IterableAssert<T> setCoder(Coder<T> coderOrNull) {
+      return this;
+    }
+
+    @Override
+    public Coder<T> getCoder() {
+      return elementCoder;
+    }
+
+    @Override
+    @SafeVarargs
+    public final PCollectionSingletonIterableAssert<T> containsInAnyOrder(T... expectedElements) {
+      return containsInAnyOrder(Arrays.asList(expectedElements));
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> empty() {
+      return containsInAnyOrder(Collections.<T>emptyList());
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
       return satisfies(new AssertContainsInAnyOrderRelation<T>(), expectedElements);
     }
 
-    /**
-     * Checks that the {@code Iterable} contains the expected elements, in any
-     * order.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    @SafeVarargs
-    public final IterableAssert<T> containsInAnyOrder(T... expectedElements) {
-      return satisfies(
-        new AssertContainsInAnyOrderRelation<T>(),
-        Arrays.asList(expectedElements));
+    @Override
+    public PCollectionSingletonIterableAssert<T> satisfies(
+        SerializableFunction<Iterable<T>, Void> checkerFn) {
+      actual.apply("DataflowAssert$" + (assertCount++),
+          new GroupThenAssertForSingleton<>(checkerFn));
+      return this;
     }
 
-    /**
-     * Checks that the {@code Iterable} contains elements that match the provided matchers,
-     * in any order.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    @SafeVarargs
-    final IterableAssert<T> containsInAnyOrder(
-        SerializableMatcher<? super T>... elementMatchers) {
-      return satisfies(SerializableMatchers.<T>containsInAnyOrder(elementMatchers));
+    private PCollectionSingletonIterableAssert<T> satisfies(
+        AssertRelation<Iterable<T>, Iterable<T>> relation, Iterable<T> expectedElements) {
+      return satisfies(
+          new CheckRelationAgainstExpected<Iterable<T>>(
+              relation, expectedElements, IterableCoder.of(elementCoder)));
     }
   }
 
   /**
-   * An assertion about the single value of type {@code T}
-   * associated with a {@link PCollectionView}.
+   * An assertion about the contents of a {@link PCollection} when it is viewed as a single value
+   * of type {@code ViewT}. This requires side input support from the runner.
    */
-  public static class SingletonAssert<T> implements Serializable {
-    private final Pipeline pipeline;
-    private final CreateActual<?, T> createActual;
-    private Optional<Coder<T>> coder;
+  private static class PCollectionViewAssert<ElemT, ViewT> implements SingletonAssert<ViewT> {
+    private final PCollection<ElemT> actual;
+    private final PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view;
+    private final Coder<ViewT> coder;
 
-    protected SingletonAssert(
-        CreateActual<?, T> createActual, Pipeline pipeline) {
-      this.pipeline = pipeline;
-      this.createActual = createActual;
-      this.coder = Optional.absent();
+    protected PCollectionViewAssert(
+        PCollection<ElemT> actual,
+        PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view,
+        Coder<ViewT> coder) {
+      this.actual = actual;
+      this.view = view;
+      this.coder = coder;
+    }
+
+    @Override
+    public SingletonAssert<ViewT> setCoder(Coder<ViewT> coderOrNull) {
+      return this;
+    }
+
+    @Override
+    public Coder<ViewT> getCoder() {
+      return coder;
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> isEqualTo(ViewT expectedValue) {
+      return satisfies(new AssertIsEqualToRelation<ViewT>(), expectedValue);
+    }
+
+    @Override
+    public SingletonAssert<ViewT> is(ViewT expected) {
+      return isEqualTo(expected);
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> notEqualTo(ViewT expectedValue) {
+      return satisfies(new AssertNotEqualToRelation<ViewT>(), expectedValue);
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> satisfies(
+        SerializableFunction<ViewT, Void> checkerFn) {
+      actual
+          .getPipeline()
+          .apply(
+              "DataflowAssert$" + (assertCount++),
+              new OneSideInputAssert<ViewT>(CreateActual.from(actual, view), checkerFn));
+      return this;
+    }
+
+    /**
+     * Applies an {@link AssertRelation} to check the provided relation against the value of this
+     * assert and the provided expected value.
+     *
+     * <p>Returns this {@code SingletonAssert}.
+     */
+    private PCollectionViewAssert<ElemT, ViewT> satisfies(
+        AssertRelation<ViewT, ViewT> relation, final ViewT expectedValue) {
+      return satisfies(new CheckRelationAgainstExpected<ViewT>(relation, expectedValue, coder));
     }
 
     /**
@@ -399,7 +575,7 @@ public class DataflowAssert {
 
     /**
      * @throws UnsupportedOperationException always.
-     * @deprecated {@link Object#hashCode()} is not supported on DataflowAssert objects.
+     * @deprecated {@link Object#hashCode()} is not supported on {@link DataflowAssert} objects.
      */
     @Deprecated
     @Override
@@ -407,92 +583,6 @@ public class DataflowAssert {
       throw new UnsupportedOperationException(
           String.format("%s.hashCode() is not supported.", SingletonAssert.class.getSimpleName()));
     }
-
-    /**
-     * Sets the coder to use for elements of type {@code T}, as needed
-     * for internal purposes.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    public SingletonAssert<T> setCoder(Coder<T> coderOrNull) {
-      this.coder = Optional.fromNullable(coderOrNull);
-      return this;
-    }
-
-    /**
-     * Gets the coder, which may yet be absent.
-     */
-    public Coder<T> getCoder() {
-      if (coder.isPresent()) {
-        return coder.get();
-      } else {
-        throw new IllegalStateException(
-            "Attempting to access the coder of an IterableAssert that has not been set yet.");
-      }
-    }
-
-    /**
-     * Applies a {@link SerializableFunction} to check the value of this
-     * {@code SingletonAssert}'s view.
-     *
-     * <p>Returns this {@code SingletonAssert}.
-     */
-    public SingletonAssert<T> satisfies(SerializableFunction<T, Void> checkerFn) {
-      pipeline.apply(
-          "DataflowAssert$" + (assertCount++),
-          new OneSideInputAssert<T>(createActual, checkerFn));
-      return this;
-    }
-
-    /**
-     * Applies an {@link AssertRelation} to check the provided relation against the
-     * value of this assert and the provided expected value.
-     *
-     * <p>Returns this {@code SingletonAssert}.
-     */
-    public SingletonAssert<T> satisfies(
-        AssertRelation<T, T> relation,
-        final T expectedValue) {
-      pipeline.apply(
-          "DataflowAssert$" + (assertCount++),
-          new TwoSideInputAssert<T, T>(createActual,
-              new CreateExpected<T, T>(Arrays.asList(expectedValue), coder, View.<T>asSingleton()),
-              relation));
-
-      return this;
-    }
-
-    /**
-     * Checks that the value of this {@code SingletonAssert}'s view is equal
-     * to the expected value.
-     *
-     * <p>Returns this {@code SingletonAssert}.
-     */
-    public SingletonAssert<T> isEqualTo(T expectedValue) {
-      return satisfies(new AssertIsEqualToRelation<T>(), expectedValue);
-    }
-
-    /**
-     * Checks that the value of this {@code SingletonAssert}'s view is not equal
-     * to the expected value.
-     *
-     * <p>Returns this {@code SingletonAssert}.
-     */
-    public SingletonAssert<T> notEqualTo(T expectedValue) {
-      return satisfies(new AssertNotEqualToRelation<T>(), expectedValue);
-    }
-
-    /**
-     * Checks that the value of this {@code SingletonAssert}'s view is equal to
-     * the expected value.
-     *
-     * @deprecated replaced by {@link #isEqualTo}
-     */
-    @Deprecated
-    public SingletonAssert<T> is(T expectedValue) {
-      return isEqualTo(expectedValue);
-    }
-
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -503,8 +593,13 @@ public class DataflowAssert {
     private final transient PCollection<T> actual;
     private final transient PTransform<PCollection<T>, PCollectionView<ActualT>> actualView;
 
-    private CreateActual(PCollection<T> actual,
-        PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
+    public static <T, ActualT> CreateActual<T, ActualT> from(
+        PCollection<T> actual, PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
+      return new CreateActual<>(actual, actualView);
+    }
+
+    private CreateActual(
+        PCollection<T> actual, PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
       this.actual = actual;
       this.actualView = actualView;
     }
@@ -514,73 +609,198 @@ public class DataflowAssert {
       final Coder<T> coder = actual.getCoder();
       return actual
           .apply(Window.<T>into(new GlobalWindows()))
-          .apply(ParDo.of(new DoFn<T, T>() {
-            @Override
-            public void processElement(ProcessContext context) throws CoderException {
-              context.output(CoderUtils.clone(coder, context.element()));
-            }
-          }))
+          .apply(
+              ParDo.of(
+                  new DoFn<T, T>() {
+                    @Override
+                    public void processElement(ProcessContext context) throws CoderException {
+                      context.output(CoderUtils.clone(coder, context.element()));
+                    }
+                  }))
           .apply(actualView);
     }
   }
 
-  private static class CreateExpected<T, ExpectedT>
-      extends PTransform<PBegin, PCollectionView<ExpectedT>> {
+  /**
+   * A partially applied {@link AssertRelation}, where one value is provided along with a coder to
+   * serialize/deserialize them.
+   */
+  private static class CheckRelationAgainstExpected<T> implements SerializableFunction<T, Void> {
+    private final AssertRelation<T, T> relation;
+    private final byte[] encodedExpected;
+    private final Coder<T> coder;
 
-    private final Iterable<T> elements;
-    private final Optional<Coder<T>> coder;
-    private final transient PTransform<PCollection<T>, PCollectionView<ExpectedT>> view;
-
-    private CreateExpected(Iterable<T> elements, Optional<Coder<T>> coder,
-        PTransform<PCollection<T>, PCollectionView<ExpectedT>> view) {
-      this.elements = elements;
+    public CheckRelationAgainstExpected(AssertRelation<T, T> relation, T expected, Coder<T> coder) {
+      this.relation = relation;
       this.coder = coder;
-      this.view = view;
-    }
 
-    @Override
-    public PCollectionView<ExpectedT> apply(PBegin input) {
-      Create.Values<T> createTransform = Create.<T>of(elements);
-      if (coder.isPresent()) {
-        createTransform = createTransform.withCoder(coder.get());
+      try {
+        this.encodedExpected = CoderUtils.encodeToByteArray(coder, expected);
+      } catch (IOException coderException) {
+        throw new RuntimeException(coderException);
       }
-      return input.apply(createTransform).apply(view);
-    }
-  }
-
-  private static class PreExisting<T> extends PTransform<PBegin, PCollectionView<T>> {
-
-    private final PCollectionView<T> view;
-
-    private PreExisting(PCollectionView<T> view) {
-      this.view = view;
     }
 
     @Override
-    public PCollectionView<T> apply(PBegin input) {
-      return view;
+    public Void apply(T actual) {
+      try {
+        T expected = CoderUtils.decodeFromByteArray(coder, encodedExpected);
+        return relation.assertFor(expected).apply(actual);
+      } catch (IOException coderException) {
+        throw new RuntimeException(coderException);
+      }
     }
   }
 
   /**
-   * An assertion checker that takes a single
-   * {@link PCollectionView PCollectionView&lt;ActualT&gt;}
-   * and an assertion over {@code ActualT}, and checks it within a dataflow
-   * pipeline.
+   * A transform that gathers the contents of a {@link PCollection} into a single main input
+   * iterable in the global window. This requires a runner to support {@link GroupByKey} in the
+   * global window, but not side inputs or other windowing or triggers.
    *
-   * <p>Note that the entire assertion must be serializable. If
-   * you need to make assertions involving multiple inputs
-   * that are each not serializable, use TwoSideInputAssert.
-   *
-   * <p>This is generally useful for assertion functions that
-   * are serializable but whose underlying data may not have a coder.
+   * <p>If the {@link PCollection} is empty, this transform returns a {@link PCollection} containing
+   * a single empty iterable, even though in practice most runners will not produce any element.
    */
-  static class OneSideInputAssert<ActualT>
-      extends PTransform<PBegin, PDone> implements Serializable {
+  private static class GroupGlobally<T> extends PTransform<PCollection<T>, PCollection<Iterable<T>>>
+      implements Serializable {
+
+    public GroupGlobally() {}
+
+    @Override
+    public PCollection<Iterable<T>> apply(PCollection<T> input) {
+
+      final int contentsKey = 0;
+      final int dummyKey = 1;
+      final int combinedKey = 42;
+
+      // Group the contents by key. If it is empty, this PCollection will be empty, too.
+      // Then key it again with a dummy key.
+      Bound<KV<Integer, T>> trigger =
+          Window.<KV<Integer, T>>triggering(Never.ever()).discardingFiredPanes();
+      PCollection<KV<Integer, KV<Integer, Iterable<T>>>> doubleKeyedGroupedInput =
+          input
+              .apply("GloballyWindow", Window.<T>into(new GlobalWindows()))
+              .apply("ContentsWithKeys", WithKeys.<Integer, T>of(contentsKey))
+              .apply("NeverTriggerContents", trigger)
+              .apply("ContentsGBK", GroupByKey.<Integer, T>create())
+              .apply(
+                  "DoubleKeyContents", WithKeys.<Integer, KV<Integer, Iterable<T>>>of(combinedKey));
+
+      // Create another non-empty PCollection that is keyed with a distinct dummy key
+      PCollection<KV<Integer, KV<Integer, Iterable<T>>>> doubleKeyedDummy =
+          input
+              .getPipeline()
+              .apply(
+                  Create.of(
+                          KV.of(
+                              combinedKey,
+                              KV.of(dummyKey, (Iterable<T>) Collections.<T>emptyList())))
+                      .withCoder(doubleKeyedGroupedInput.getCoder()))
+              .setWindowingStrategyInternal(doubleKeyedGroupedInput.getWindowingStrategy());
+
+      // Flatten them together and group by the combined key to get a single element
+      PCollection<KV<Integer, Iterable<KV<Integer, Iterable<T>>>>> dummyAndContents =
+          PCollectionList.<KV<Integer, KV<Integer, Iterable<T>>>>of(doubleKeyedGroupedInput)
+              .and(doubleKeyedDummy)
+              .apply(
+                  "FlattenDummyAndContents",
+                  Flatten.<KV<Integer, KV<Integer, Iterable<T>>>>pCollections())
+              .apply(
+                  "GroupDummyAndContents", GroupByKey.<Integer, KV<Integer, Iterable<T>>>create());
+
+      // Extract the contents if they exist else empty contents.
+      return dummyAndContents
+          .apply(
+              "GetContents",
+              ParDo.of(
+                  new DoFn<KV<Integer, Iterable<KV<Integer, Iterable<T>>>>, Iterable<T>>() {
+                    @Override
+                    public void processElement(ProcessContext ctx) {
+                      Iterable<KV<Integer, Iterable<T>>> groupedDummyAndContents =
+                          ctx.element().getValue();
+
+                      if (Iterables.size(groupedDummyAndContents) == 1) {
+                        // Only the dummy value, so just output empty
+                        ctx.output(Collections.<T>emptyList());
+                      } else {
+                        checkState(
+                            Iterables.size(groupedDummyAndContents) == 2,
+                            "Internal error: DataflowAssert grouped contents with a"
+                                + " dummy value resulted in more than 2 groupings: %s",
+                                groupedDummyAndContents);
+
+                        if (Iterables.get(groupedDummyAndContents, 0).getKey() == contentsKey) {
+                          // The first iterable in the group holds the real contents
+                          ctx.output(Iterables.get(groupedDummyAndContents, 0).getValue());
+                        } else {
+                          // The second iterable holds the real contents
+                          ctx.output(Iterables.get(groupedDummyAndContents, 1).getValue());
+                        }
+                      }
+                    }
+                  }));
+    }
+  }
+
+  /**
+   * A transform that applies an assertion-checking function over iterables of {@code ActualT} to
+   * the entirety of the contents of its input.
+   */
+  public static class GroupThenAssert<T> extends PTransform<PCollection<T>, PDone>
+      implements Serializable {
+    private final SerializableFunction<Iterable<T>, Void> checkerFn;
+
+    private GroupThenAssert(SerializableFunction<Iterable<T>, Void> checkerFn) {
+      this.checkerFn = checkerFn;
+    }
+
+    @Override
+    public PDone apply(PCollection<T> input) {
+      input
+          .apply("GroupGlobally", new GroupGlobally<T>())
+          .apply("RunChecks", ParDo.of(new GroupedValuesCheckerDoFn<>(checkerFn)));
+
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  /**
+   * A transform that applies an assertion-checking function to a single iterable contained as the
+   * sole element of a {@link PCollection}.
+   */
+  public static class GroupThenAssertForSingleton<T>
+      extends PTransform<PCollection<Iterable<T>>, PDone> implements Serializable {
+    private final SerializableFunction<Iterable<T>, Void> checkerFn;
+
+    private GroupThenAssertForSingleton(SerializableFunction<Iterable<T>, Void> checkerFn) {
+      this.checkerFn = checkerFn;
+    }
+
+    @Override
+    public PDone apply(PCollection<Iterable<T>> input) {
+      input
+          .apply("GroupGlobally", new GroupGlobally<Iterable<T>>())
+          .apply("RunChecks", ParDo.of(new SingletonCheckerDoFn<>(checkerFn)));
+
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  /**
+   * An assertion checker that takes a single {@link PCollectionView
+   * PCollectionView&lt;ActualT&gt;} and an assertion over {@code ActualT}, and checks it within a
+   * Beam pipeline.
+   *
+   * <p>Note that the entire assertion must be serializable.
+   *
+   * <p>This is generally useful for assertion functions that are serializable but whose underlying
+   * data may not have a coder.
+   */
+  public static class OneSideInputAssert<ActualT> extends PTransform<PBegin, PDone>
+      implements Serializable {
     private final transient PTransform<PBegin, PCollectionView<ActualT>> createActual;
     private final SerializableFunction<ActualT, Void> checkerFn;
 
-    public OneSideInputAssert(
+    private OneSideInputAssert(
         PTransform<PBegin, PCollectionView<ActualT>> createActual,
         SerializableFunction<ActualT, Void> checkerFn) {
       this.createActual = createActual;
@@ -592,19 +812,24 @@ public class DataflowAssert {
       final PCollectionView<ActualT> actual = input.apply("CreateActual", createActual);
 
       input
-          .apply(Create.<Void>of((Void) null).withCoder(VoidCoder.of()))
-          .apply(ParDo.named("RunChecks").withSideInputs(actual)
-              .of(new CheckerDoFn<>(checkerFn, actual)));
+          .apply(Create.of(0).withCoder(VarIntCoder.of()))
+          .apply(
+              ParDo.named("RunChecks")
+                  .withSideInputs(actual)
+                  .of(new SideInputCheckerDoFn<>(checkerFn, actual)));
 
       return PDone.in(input.getPipeline());
     }
   }
 
   /**
-   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
-   * a {@link PCollectionView}, and adjusts counters and thrown exceptions for use in testing.
+   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of a
+   * {@link PCollectionView}, and adjusts counters and thrown exceptions for use in testing.
+   *
+   * <p>The input is ignored, but is {@link Integer} to be usable on runners that do not support
+   * null values.
    */
-  private static class CheckerDoFn<ActualT> extends DoFn<Void, Void> {
+  private static class SideInputCheckerDoFn<ActualT> extends DoFn<Integer, Void> {
     private final SerializableFunction<ActualT, Void> checkerFn;
     private final Aggregator<Integer, Integer> success =
         createAggregator(SUCCESS_COUNTER, new Sum.SumIntegerFn());
@@ -612,9 +837,8 @@ public class DataflowAssert {
         createAggregator(FAILURE_COUNTER, new Sum.SumIntegerFn());
     private final PCollectionView<ActualT> actual;
 
-    private CheckerDoFn(
-        SerializableFunction<ActualT, Void> checkerFn,
-        PCollectionView<ActualT> actual) {
+    private SideInputCheckerDoFn(
+        SerializableFunction<ActualT, Void> checkerFn, PCollectionView<ActualT> actual) {
       this.checkerFn = checkerFn;
       this.actual = actual;
     }
@@ -623,12 +847,9 @@ public class DataflowAssert {
     public void processElement(ProcessContext c) {
       try {
         ActualT actualContents = c.sideInput(actual);
-        checkerFn.apply(actualContents);
-        success.addValue(1);
+        doChecks(actualContents, checkerFn, success, failure);
       } catch (Throwable t) {
-        LOG.error("DataflowAssert failed expectations.", t);
-        failure.addValue(1);
-        // TODO: allow for metrics to propagate on failure when running a streaming pipeline
+        // Suppress exception in streaming
         if (!c.getPipelineOptions().as(StreamingOptions.class).isStreaming()) {
           throw t;
         }
@@ -637,84 +858,89 @@ public class DataflowAssert {
   }
 
   /**
-   * An assertion checker that takes a {@link PCollectionView PCollectionView&lt;ActualT&gt;},
-   * a {@link PCollectionView PCollectionView&lt;ExpectedT&gt;}, a relation
-   * over {@code A} and {@code B}, and checks that the relation holds
-   * within a dataflow pipeline.
+   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
+   * the single iterable element of the input {@link PCollection} and adjusts counters and
+   * thrown exceptions for use in testing.
    *
-   * <p>This is useful when either/both of {@code A} and {@code B}
-   * are not serializable, but have coders (provided
-   * by the underlying {@link PCollection}s).
+   * <p>The singleton property is presumed, not enforced.
    */
-  static class TwoSideInputAssert<ActualT, ExpectedT>
-      extends PTransform<PBegin, PDone> implements Serializable {
+  private static class GroupedValuesCheckerDoFn<ActualT> extends DoFn<ActualT, Void> {
+    private final SerializableFunction<ActualT, Void> checkerFn;
+    private final Aggregator<Integer, Integer> success =
+        createAggregator(SUCCESS_COUNTER, new Sum.SumIntegerFn());
+    private final Aggregator<Integer, Integer> failure =
+        createAggregator(FAILURE_COUNTER, new Sum.SumIntegerFn());
 
-    private final transient PTransform<PBegin, PCollectionView<ActualT>> createActual;
-    private final transient PTransform<PBegin, PCollectionView<ExpectedT>> createExpected;
-    private final AssertRelation<ActualT, ExpectedT> relation;
-
-    protected TwoSideInputAssert(
-        PTransform<PBegin, PCollectionView<ActualT>> createActual,
-        PTransform<PBegin, PCollectionView<ExpectedT>> createExpected,
-        AssertRelation<ActualT, ExpectedT> relation) {
-      this.createActual = createActual;
-      this.createExpected = createExpected;
-      this.relation = relation;
+    private GroupedValuesCheckerDoFn(SerializableFunction<ActualT, Void> checkerFn) {
+      this.checkerFn = checkerFn;
     }
 
     @Override
-    public PDone apply(PBegin input) {
-      final PCollectionView<ActualT> actual = input.apply("CreateActual", createActual);
-      final PCollectionView<ExpectedT> expected = input.apply("CreateExpected", createExpected);
-
-      input
-          .apply(Create.<Void>of((Void) null).withCoder(VoidCoder.of()))
-          .apply(ParDo.named("RunChecks").withSideInputs(actual, expected)
-              .of(new CheckerDoFn<>(relation, actual, expected)));
-
-      return PDone.in(input.getPipeline());
-    }
-
-    private static class CheckerDoFn<ActualT, ExpectedT> extends DoFn<Void, Void> {
-      private final Aggregator<Integer, Integer> success =
-          createAggregator(SUCCESS_COUNTER, new Sum.SumIntegerFn());
-      private final Aggregator<Integer, Integer> failure =
-          createAggregator(FAILURE_COUNTER, new Sum.SumIntegerFn());
-      private final AssertRelation<ActualT, ExpectedT> relation;
-      private final PCollectionView<ActualT> actual;
-      private final PCollectionView<ExpectedT> expected;
-
-      private CheckerDoFn(AssertRelation<ActualT, ExpectedT> relation,
-          PCollectionView<ActualT> actual, PCollectionView<ExpectedT> expected) {
-        this.relation = relation;
-        this.actual = actual;
-        this.expected = expected;
-      }
-
-      @Override
-      public void processElement(ProcessContext c) {
-        try {
-          ActualT actualContents = c.sideInput(actual);
-          ExpectedT expectedContents = c.sideInput(expected);
-          relation.assertFor(expectedContents).apply(actualContents);
-          success.addValue(1);
-        } catch (Throwable t) {
-          LOG.error("DataflowAssert failed expectations.", t);
-          failure.addValue(1);
-          // TODO: allow for metrics to propagate on failure when running a streaming pipeline
-          if (!c.getPipelineOptions().as(StreamingOptions.class).isStreaming()) {
-            throw t;
-          }
+    public void processElement(ProcessContext c) {
+      try {
+        doChecks(c.element(), checkerFn, success, failure);
+      } catch (Throwable t) {
+        // Suppress exception in streaming
+        if (!c.getPipelineOptions().as(StreamingOptions.class).isStreaming()) {
+          throw t;
         }
       }
+    }
+  }
+
+  /**
+   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
+   * the single item contained within the single iterable on input and
+   * adjusts counters and thrown exceptions for use in testing.
+   *
+   * <p>The singleton property of the input {@link PCollection} is presumed, not enforced. However,
+   * each input element must be a singleton iterable, or this will fail.
+   */
+  private static class SingletonCheckerDoFn<ActualT> extends DoFn<Iterable<ActualT>, Void> {
+    private final SerializableFunction<ActualT, Void> checkerFn;
+    private final Aggregator<Integer, Integer> success =
+        createAggregator(SUCCESS_COUNTER, new Sum.SumIntegerFn());
+    private final Aggregator<Integer, Integer> failure =
+        createAggregator(FAILURE_COUNTER, new Sum.SumIntegerFn());
+
+    private SingletonCheckerDoFn(SerializableFunction<ActualT, Void> checkerFn) {
+      this.checkerFn = checkerFn;
+    }
+
+    @Override
+    public void processElement(ProcessContext c) {
+      try {
+        ActualT actualContents = Iterables.getOnlyElement(c.element());
+        doChecks(actualContents, checkerFn, success, failure);
+      } catch (Throwable t) {
+        // Suppress exception in streaming
+        if (!c.getPipelineOptions().as(StreamingOptions.class).isStreaming()) {
+          throw t;
+        }
+      }
+    }
+  }
+
+  private static <ActualT> void doChecks(
+      ActualT actualContents,
+      SerializableFunction<ActualT, Void> checkerFn,
+      Aggregator<Integer, Integer> successAggregator,
+      Aggregator<Integer, Integer> failureAggregator) {
+    try {
+      checkerFn.apply(actualContents);
+      successAggregator.addValue(1);
+    } catch (Throwable t) {
+      LOG.error("DataflowAssert failed expectations.", t);
+      failureAggregator.addValue(1);
+      throw t;
     }
   }
 
   /////////////////////////////////////////////////////////////////////////////
 
   /**
-   * A {@link SerializableFunction} that verifies that an actual value is equal to an
-   * expected value.
+   * A {@link SerializableFunction} that verifies that an actual value is equal to an expected
+   * value.
    */
   private static class AssertIsEqualTo<T> implements SerializableFunction<T, Void> {
     private T expected;
@@ -731,8 +957,8 @@ public class DataflowAssert {
   }
 
   /**
-   * A {@link SerializableFunction} that verifies that an actual value is not equal to an
-   * expected value.
+   * A {@link SerializableFunction} that verifies that an actual value is not equal to an expected
+   * value.
    */
   private static class AssertNotEqualTo<T> implements SerializableFunction<T, Void> {
     private T expected;
@@ -749,8 +975,8 @@ public class DataflowAssert {
   }
 
   /**
-   * A {@link SerializableFunction} that verifies that an {@code Iterable} contains
-   * expected items in any order.
+   * A {@link SerializableFunction} that verifies that an {@code Iterable} contains expected items
+   * in any order.
    */
   private static class AssertContainsInAnyOrder<T>
       implements SerializableFunction<Iterable<T>, Void> {
@@ -780,10 +1006,9 @@ public class DataflowAssert {
   ////////////////////////////////////////////////////////////
 
   /**
-   * A binary predicate between types {@code Actual} and {@code Expected}.
-   * Implemented as a method {@code assertFor(Expected)} which returns
-   * a {@code SerializableFunction<Actual, Void>}
-   * that should verify the assertion..
+   * A binary predicate between types {@code Actual} and {@code Expected}. Implemented as a method
+   * {@code assertFor(Expected)} which returns a {@code SerializableFunction<Actual, Void>} that
+   * should verify the assertion..
    */
   private static interface AssertRelation<ActualT, ExpectedT> extends Serializable {
     public SerializableFunction<ActualT, Void> assertFor(ExpectedT input);
@@ -792,8 +1017,7 @@ public class DataflowAssert {
   /**
    * An {@link AssertRelation} implementing the binary predicate that two objects are equal.
    */
-  private static class AssertIsEqualToRelation<T>
-      implements AssertRelation<T, T> {
+  private static class AssertIsEqualToRelation<T> implements AssertRelation<T, T> {
     @Override
     public SerializableFunction<T, Void> assertFor(T expected) {
       return new AssertIsEqualTo<T>(expected);
@@ -803,8 +1027,7 @@ public class DataflowAssert {
   /**
    * An {@link AssertRelation} implementing the binary predicate that two objects are not equal.
    */
-  private static class AssertNotEqualToRelation<T>
-      implements AssertRelation<T, T> {
+  private static class AssertNotEqualToRelation<T> implements AssertRelation<T, T> {
     @Override
     public SerializableFunction<T, Void> assertFor(T expected) {
       return new AssertNotEqualTo<T>(expected);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/PaneExtractors.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/PaneExtractors.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.testing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.SimpleFunction;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo.Timing;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.TypeDescriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link PTransform PTransforms} which take an {@link Iterable} of {@link WindowedValue
+ * WindowedValues} and outputs an {@link Iterable} of all values in the specified pane, dropping the
+ * {@link WindowedValue} metadata.
+ *
+ * <p>Although all of the method signatures return SimpleFunction, users should ensure to set the
+ * coder of any output {@link PCollection}, as appropriate {@link TypeDescriptor TypeDescriptors}
+ * cannot be obtained when the extractor is created.
+ */
+final class PaneExtractors {
+  private PaneExtractors() {
+  }
+
+  static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> onlyPane() {
+    return new ExtractOnlyPane<>();
+  }
+
+  static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> onTimePane() {
+    return new ExtractOnTimePane<>();
+  }
+
+  static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> finalPane() {
+    return new ExtractFinalPane<>();
+  }
+
+  static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> nonLatePanes() {
+    return new ExtractNonLatePanes<>();
+  }
+
+  static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> allPanes() {
+    return new ExtractAllPanes<>();
+  }
+
+  private static class ExtractOnlyPane<T>
+      extends SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> {
+    @Override
+    public Iterable<T> apply(Iterable<WindowedValue<T>> input) {
+      List<T> outputs = new ArrayList<>();
+      for (WindowedValue<T> value : input) {
+        checkState(value.getPane().isFirst() && value.getPane().isLast(),
+            "Expected elements to be produced by a trigger that fires at most once, but got"
+                + "a value in a pane that is %s. Actual Pane Info: %s",
+            value.getPane().isFirst() ? "not the last pane" : "not the first pane",
+            value.getPane());
+        outputs.add(value.getValue());
+      }
+      return outputs;
+    }
+  }
+
+
+  private static class ExtractOnTimePane<T>
+      extends SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> {
+    @Override
+    public Iterable<T> apply(Iterable<WindowedValue<T>> input) {
+      List<T> outputs = new ArrayList<>();
+      for (WindowedValue<T> value : input) {
+        if (value.getPane().getTiming().equals(Timing.ON_TIME)) {
+          outputs.add(value.getValue());
+        }
+      }
+      return outputs;
+    }
+  }
+
+
+  private static class ExtractFinalPane<T>
+      extends SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> {
+    @Override
+    public Iterable<T> apply(Iterable<WindowedValue<T>> input) {
+      List<T> outputs = new ArrayList<>();
+      for (WindowedValue<T> value : input) {
+        if (value.getPane().isLast()) {
+          outputs.add(value.getValue());
+        }
+      }
+      return outputs;
+    }
+  }
+
+
+  private static class ExtractAllPanes<T>
+      extends SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> {
+    @Override
+    public Iterable<T> apply(Iterable<WindowedValue<T>> input) {
+      List<T> outputs = new ArrayList<>();
+      for (WindowedValue<T> value : input) {
+        outputs.add(value.getValue());
+      }
+      return outputs;
+    }
+  }
+
+
+  private static class ExtractNonLatePanes<T>
+      extends SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> {
+    @Override
+    public Iterable<T> apply(Iterable<WindowedValue<T>> input) {
+      List<T> outputs = new ArrayList<>();
+      for (WindowedValue<T> value : input) {
+        if (value.getPane().getTiming() != PaneInfo.Timing.LATE) {
+          outputs.add(value.getValue());
+        }
+      }
+      return outputs;
+    }
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/StaticWindows.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/StaticWindows.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.testing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.NonMergingWindowFn;
+import com.google.cloud.dataflow.sdk.transforms.windowing.WindowFn;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import org.joda.time.Instant;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+/**
+ * A {@link WindowFn} that assigns all elements to a static collection of
+ * {@link BoundedWindow BoundedWindows}. Side inputs windowed into static windows only support
+ * main input windows in the provided collection of windows.
+ */
+final class StaticWindows extends NonMergingWindowFn<Object, BoundedWindow> {
+  private final Supplier<Collection<BoundedWindow>> windows;
+  private final Coder<BoundedWindow> coder;
+
+  private final boolean onlyExisting;
+
+  private StaticWindows(
+      Supplier<Collection<BoundedWindow>> windows,
+      Coder<BoundedWindow> coder,
+      boolean onlyExisting) {
+    this.windows = windows;
+    this.coder = coder;
+    this.onlyExisting = onlyExisting;
+  }
+
+  public static <W extends BoundedWindow> StaticWindows of(Coder<W> coder, Iterable<W> windows) {
+    checkArgument(!Iterables.isEmpty(windows), "Input windows to StaticWindows may not be empty");
+    @SuppressWarnings("unchecked")
+    StaticWindows windowFn =
+        new StaticWindows(
+            WindowSupplier.of((Coder<BoundedWindow>) coder, (Iterable<BoundedWindow>) windows),
+            (Coder<BoundedWindow>) coder,
+            false);
+    return windowFn;
+  }
+
+  public static <W extends BoundedWindow> StaticWindows of(Coder<W> coder, W window) {
+    return of(coder, Collections.singleton(window));
+  }
+
+  public StaticWindows intoOnlyExisting() {
+    return new StaticWindows(windows, coder, true);
+  }
+
+  public Collection<BoundedWindow> getWindows() {
+    return windows.get();
+  }
+
+  @Override
+  public Collection<BoundedWindow> assignWindows(AssignContext c) throws Exception {
+    if (onlyExisting) {
+      checkArgument(
+          windows.get().containsAll(c.windows()),
+          "Tried to assign windows to an element that is not already windowed into a provided "
+              + "window when onlyExisting is set to true");
+      return ImmutableList.copyOf(c.windows());
+    } else {
+      return getWindows();
+    }
+  }
+
+  @Override
+  public boolean isCompatible(WindowFn<?, ?> other) {
+    if (!(other instanceof StaticWindows)) {
+      return false;
+    }
+    StaticWindows that = (StaticWindows) other;
+    return Objects.equals(this.windows.get(), that.windows.get());
+  }
+
+  @Override
+  public Coder<BoundedWindow> windowCoder() {
+    return coder;
+  }
+
+  @Override
+  public BoundedWindow getSideInputWindow(BoundedWindow window) {
+    checkArgument(windows.get().contains(window),
+        "StaticWindows only supports side input windows for main input windows that it contains");
+    return window;
+  }
+
+  @Override
+  public Instant getOutputTime(Instant inputTimestamp, BoundedWindow window) {
+    return inputTimestamp;
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/TestDataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/TestDataflowPipelineRunner.java
@@ -158,7 +158,8 @@ public class TestDataflowPipelineRunner extends PipelineRunner<DataflowPipelineJ
   public <OutputT extends POutput, InputT extends PInput> OutputT apply(
       PTransform<InputT, OutputT> transform, InputT input) {
     if (transform instanceof DataflowAssert.OneSideInputAssert
-        || transform instanceof DataflowAssert.TwoSideInputAssert) {
+        || transform instanceof DataflowAssert.GroupThenAssert
+        || transform instanceof DataflowAssert.GroupThenAssertForSingleton) {
       expectedNumberOfAssertions += 1;
     }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/WindowSupplier.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/WindowSupplier.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.testing;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.util.CoderUtils;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * A {@link Supplier} that returns a static set of {@link BoundedWindow BoundedWindows}. The
+ * supplier is {@link Serializable}, and handles encoding and decoding the windows with a
+ * {@link Coder} provided for the windows.
+ */
+final class WindowSupplier implements Supplier<Collection<BoundedWindow>>, Serializable {
+  private final Coder<? extends BoundedWindow> coder;
+  private final Collection<byte[]> encodedWindows;
+
+  private transient Collection<BoundedWindow> windows;
+
+  public static <W extends BoundedWindow> WindowSupplier of(Coder<W> coder, Iterable<W> windows) {
+    ImmutableSet.Builder<byte[]> windowsBuilder = ImmutableSet.builder();
+    for (W window : windows) {
+      try {
+        windowsBuilder.add(CoderUtils.encodeToByteArray(coder, window));
+      } catch (CoderException e) {
+        throw new IllegalArgumentException(
+            "Could not encode provided windows with the provided window coder", e);
+      }
+    }
+    return new WindowSupplier(coder, windowsBuilder.build());
+  }
+
+  private WindowSupplier(Coder<? extends BoundedWindow> coder, Collection<byte[]> encodedWindows) {
+    this.coder = coder;
+    this.encodedWindows = encodedWindows;
+  }
+
+  @Override
+  public Collection<BoundedWindow> get() {
+    if (windows == null) {
+      decodeWindows();
+    }
+    return windows;
+  }
+
+  private synchronized void decodeWindows() {
+    if (windows == null) {
+      ImmutableList.Builder<BoundedWindow> windowsBuilder = ImmutableList.builder();
+      for (byte[] encoded : encodedWindows) {
+        try {
+          windowsBuilder.add(CoderUtils.decodeFromByteArray(coder, encoded));
+        } catch (CoderException e) {
+          throw new IllegalArgumentException(
+              "Could not decode provided windows with the provided window coder", e);
+        }
+      }
+      this.windows = windowsBuilder.build();
+    }
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/DataflowAssertTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/DataflowAssertTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.cloud.dataflow.sdk.transforms.View;
 import com.google.cloud.dataflow.sdk.transforms.windowing.FixedWindows;
 import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindow;
 import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
@@ -36,6 +37,7 @@ import com.google.cloud.dataflow.sdk.transforms.windowing.SlidingWindows;
 import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
 import com.google.cloud.dataflow.sdk.util.common.ElementByteSizeObserver;
 import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PCollectionView;
 import com.google.cloud.dataflow.sdk.values.TimestampedValue;
 import com.google.common.collect.Iterables;
 
@@ -199,6 +201,17 @@ public class DataflowAssertTest implements Serializable {
         });
 
     pipeline.run();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testContainsInAnyOrderIterableView() {
+    Pipeline p = TestPipeline.create();
+    PCollectionView<Iterable<Integer>> iterableView =
+        p.apply(Create.of(1, 2, 3, 4)).apply(View.<Integer>asIterable());
+
+    DataflowAssert.thatIterable(iterableView).containsInAnyOrder(4, 3, 2, 1);
+    p.run();
   }
 
   /**

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/DataflowAssertTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/DataflowAssertTest.java
@@ -285,10 +285,10 @@ public class DataflowAssertTest implements Serializable {
             TimestampedValue.of(22, new Instant(-250L))))
             .apply(Window.<Integer>into(FixedWindows.of(Duration.millis(500L))));
     DataflowAssert.thatSingleton(pcollection)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(500L)))
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(500L)))
         .isEqualTo(43);
     DataflowAssert.thatSingleton(pcollection)
-        .inWindow(new IntervalWindow(new Instant(-500L), new Instant(0L)))
+        .inOnlyPane(new IntervalWindow(new Instant(-500L), new Instant(0L)))
         .isEqualTo(22);
     pipeline.run();
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/DataflowAssertTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/DataflowAssertTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.dataflow.sdk.testing;
 
-import static com.google.cloud.dataflow.sdk.testing.SerializableMatchers.anything;
-import static com.google.cloud.dataflow.sdk.testing.SerializableMatchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -152,30 +150,6 @@ public class DataflowAssertTest implements Serializable {
         });
 
     pipeline.run();
-  }
-
-  /**
-   * Basic test of succeeding {@link DataflowAssert} using a {@link SerializableMatcher}.
-   */
-  @Test
-  @Category(RunnableOnService.class)
-  public void testBasicMatcherSuccess() throws Exception {
-    Pipeline pipeline = TestPipeline.create();
-    PCollection<Integer> pcollection = pipeline.apply(Create.of(42));
-    DataflowAssert.that(pcollection).containsInAnyOrder(anything());
-    pipeline.run();
-  }
-
-  /**
-   * Basic test of failing {@link DataflowAssert} using a {@link SerializableMatcher}.
-   */
-  @Test
-  @Category(RunnableOnService.class)
-  public void testBasicMatcherFailure() throws Exception {
-    Pipeline pipeline = TestPipeline.create();
-    PCollection<Integer> pcollection = pipeline.apply(Create.of(42));
-    DataflowAssert.that(pcollection).containsInAnyOrder(not(anything()));
-    runExpectingAssertionFailure(pipeline);
   }
 
   /**

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/PaneExtractorsTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/PaneExtractorsTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.testing;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo;
+import com.google.cloud.dataflow.sdk.transforms.windowing.PaneInfo.Timing;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+import com.google.common.collect.ImmutableList;
+
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link PaneExtractors}.
+ */
+@RunWith(JUnit4.class)
+public class PaneExtractorsTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void onlyPaneNoFiring() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.onlyPane();
+    Iterable<WindowedValue<Integer>> noFiring =
+        ImmutableList.of(
+            WindowedValue.valueInGlobalWindow(9), WindowedValue.valueInEmptyWindows(19));
+    assertThat(extractor.apply(noFiring), containsInAnyOrder(9, 19));
+  }
+
+  @Test
+  public void onlyPaneOnlyOneFiring() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.onlyPane();
+    Iterable<WindowedValue<Integer>> onlyFiring =
+        ImmutableList.of(
+            WindowedValue.of(
+                2, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING),
+            WindowedValue.of(
+                1, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING));
+
+    assertThat(extractor.apply(onlyFiring), containsInAnyOrder(2, 1));
+  }
+
+  @Test
+  public void onlyPaneMultiplePanesFails() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.onlyPane();
+    Iterable<WindowedValue<Integer>> multipleFiring =
+        ImmutableList.of(
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)),
+            WindowedValue.of(
+                2,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                1,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.LATE, 2L, 1L)));
+
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("trigger that fires at most once");
+    extractor.apply(multipleFiring);
+  }
+
+  @Test
+  public void onTimePane() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.onTimePane();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                2,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(2, 4));
+  }
+
+  @Test
+  public void onTimePaneOnlyEarlyAndLate() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.onTimePane();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.LATE, 2L, 1L)),
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                2,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                1,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(2, 4));
+  }
+
+  @Test
+  public void finalPane() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.finalPane();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, true, Timing.LATE, 2L, 1L)),
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                1,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(8));
+  }
+
+  @Test
+  public void finalPaneNoExplicitFinalEmpty() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.finalPane();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.LATE, 2L, 1L)),
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                1,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)));
+
+    assertThat(extractor.apply(onlyOnTime), emptyIterable());
+  }
+
+  @Test
+  public void nonLatePanesSingleOnTime() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.nonLatePanes();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING),
+            WindowedValue.of(
+                4, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING),
+            WindowedValue.of(
+                2, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(2, 4, 8));
+  }
+
+  @Test
+  public void nonLatePanesSingleEarly() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.nonLatePanes();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)),
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(4, 8));
+  }
+
+  @Test
+  public void allPanesSingleLate() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.nonLatePanes();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.LATE, 0L, 0L)));
+
+    assertThat(extractor.apply(onlyOnTime), emptyIterable());
+  }
+
+  @Test
+  public void nonLatePanesMultiplePanes() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.nonLatePanes();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.LATE, 2L, 1L)),
+            WindowedValue.of(7, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING),
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                1,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(4, 1, 7));
+  }
+
+  @Test
+  public void allPanesSinglePane() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.allPanes();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING),
+            WindowedValue.of(
+                4, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING),
+            WindowedValue.of(
+                2, new Instant(0L), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(2, 4, 8));
+  }
+
+  @Test
+  public void allPanesMultiplePanes() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.allPanes();
+    Iterable<WindowedValue<Integer>> onlyOnTime =
+        ImmutableList.of(
+            WindowedValue.of(
+                8,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.LATE, 2L, 1L)),
+            WindowedValue.of(
+                4,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(false, false, Timing.ON_TIME, 1L, 0L)),
+            WindowedValue.of(
+                1,
+                new Instant(0L),
+                GlobalWindow.INSTANCE,
+                PaneInfo.createPane(true, false, Timing.EARLY)));
+
+    assertThat(extractor.apply(onlyOnTime), containsInAnyOrder(4, 8, 1));
+  }
+
+  @Test
+  public void allPanesEmpty() {
+    SerializableFunction<Iterable<WindowedValue<Integer>>, Iterable<Integer>> extractor =
+        PaneExtractors.allPanes();
+    Iterable<WindowedValue<Integer>> noPanes = ImmutableList.of();
+
+    assertThat(extractor.apply(noPanes), emptyIterable());
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/StaticWindowsTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/StaticWindowsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.testing;
+
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.WindowFn;
+import com.google.common.collect.ImmutableList;
+
+import org.hamcrest.Matchers;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link StaticWindows}.
+ */
+@RunWith(JUnit4.class)
+public class StaticWindowsTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private final IntervalWindow first = new IntervalWindow(new Instant(0), new Instant(100_000L));
+  private final IntervalWindow second =
+      new IntervalWindow(new Instant(1_000_000L), GlobalWindow.INSTANCE.maxTimestamp());
+
+  @Test
+  public void singleWindowSucceeds() throws Exception {
+    WindowFn<Object, BoundedWindow> fn = StaticWindows.of(IntervalWindow.getCoder(), first);
+    assertThat(WindowFnTestUtils.assignedWindows(fn, 100L),
+        Matchers.<BoundedWindow>contains(first));
+    assertThat(WindowFnTestUtils.assignedWindows(fn, -100L),
+        Matchers.<BoundedWindow>contains(first));
+  }
+
+  @Test
+  public void multipleWindowsSucceeds() throws Exception {
+    WindowFn<Object, BoundedWindow> fn =
+        StaticWindows.of(IntervalWindow.getCoder(), ImmutableList.of(first, second));
+    assertThat(WindowFnTestUtils.assignedWindows(fn, 100L),
+        Matchers.<BoundedWindow>containsInAnyOrder(first, second));
+    assertThat(WindowFnTestUtils.assignedWindows(fn, 1_000_000_000L),
+        Matchers.<BoundedWindow>containsInAnyOrder(first, second));
+    assertThat(WindowFnTestUtils.assignedWindows(fn, -100L),
+        Matchers.<BoundedWindow>containsInAnyOrder(first, second));
+  }
+
+  @Test
+  public void getSideInputWindowIdentity() {
+    WindowFn<Object, BoundedWindow> fn =
+        StaticWindows.of(IntervalWindow.getCoder(), ImmutableList.of(first, second));
+
+    assertThat(fn.getSideInputWindow(first), Matchers.<BoundedWindow>equalTo(first));
+    assertThat(fn.getSideInputWindow(second), Matchers.<BoundedWindow>equalTo(second));
+  }
+
+  @Test
+  public void getSideInputWindowNotPresent() {
+    WindowFn<Object, BoundedWindow> fn =
+        StaticWindows.of(IntervalWindow.getCoder(), ImmutableList.of(second));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("contains");
+    fn.getSideInputWindow(first);
+  }
+
+  @Test
+  public void emptyIterableThrows() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("may not be empty");
+    StaticWindows.of(GlobalWindow.Coder.INSTANCE, ImmutableList.<GlobalWindow>of());
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/WindowSupplierTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/WindowSupplierTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.testing;
+
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.coders.AtomicCoder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
+import com.google.cloud.dataflow.sdk.util.SerializableUtils;
+import com.google.common.collect.ImmutableList;
+
+import org.hamcrest.Matchers;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+
+/**
+ * Tests for {@link WindowSupplier}.
+ */
+public class WindowSupplierTest {
+  private final IntervalWindow window = new IntervalWindow(new Instant(0L), new Instant(100L));
+  private final IntervalWindow otherWindow =
+      new IntervalWindow(new Instant(-100L), new Instant(100L));
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getReturnsProvidedWindows() {
+    assertThat(
+        WindowSupplier.of(IntervalWindow.getCoder(), ImmutableList.of(window, otherWindow)).get(),
+        Matchers.<BoundedWindow>containsInAnyOrder(otherWindow, window));
+  }
+
+  @Test
+  public void getAfterSerialization() {
+    WindowSupplier supplier =
+        WindowSupplier.of(IntervalWindow.getCoder(), ImmutableList.of(window, otherWindow));
+    assertThat(
+        SerializableUtils.clone(supplier).get(),
+        Matchers.<BoundedWindow>containsInAnyOrder(otherWindow, window));
+  }
+
+  @Test
+  public void unencodableWindowFails() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Could not encode");
+    WindowSupplier.of(
+        new FailingCoder(),
+        Collections.<BoundedWindow>singleton(window));
+  }
+
+  private static class FailingCoder extends AtomicCoder<BoundedWindow> {
+    @Override
+    public void encode(
+        BoundedWindow value, OutputStream outStream, Context context)
+        throws CoderException, IOException {
+      throw new CoderException("Test Enccode Exception");
+    }
+
+    @Override
+    public BoundedWindow decode(
+        InputStream inStream, Context context) throws CoderException, IOException {
+      throw new CoderException("Test Decode Exception");
+    }
+  }
+}


### PR DESCRIPTION
This backports the GroupByKey-based PAssert, plus Window and Pane matching.

Additionally, it implements and deprecates DataflowAssert#thatIterable in order to maintain
backwards compatibility, and expands the IterableAssert and SingletonAssert interfaces to
maintain method visibility.

Backports https://github.com/apache/incubator-beam/pull/471
Backports https://github.com/apache/incubator-beam/pull/518
Backports https://github.com/apache/incubator-beam/pull/532