### PR TITLE
Run rejected BigQueryTableInserter tasks in the calling thread

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryTableInserter.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryTableInserter.java
@@ -80,8 +80,12 @@ public class BigQueryTableInserter {
   private final TableReference defaultRef;
   private final long maxRowsPerBatch;
 
-  private static final ExecutorService executor = MoreExecutors.getExitingExecutorService(
-      (ThreadPoolExecutor) Executors.newFixedThreadPool(100), 10, TimeUnit.SECONDS);
+  private static final ExecutorService executor;
+  static {
+    ThreadPoolExecutor tempExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(100);
+    tempExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    executor = MoreExecutors.getExitingExecutorService(tempExecutor, 10, TimeUnit.SECONDS);
+  }
 
   /**
    * Constructs a new row inserter.


### PR DESCRIPTION
Otherwise, even temporary bursts of data will cause failures as the thread pool's queue is saturated.

R: @dhalperi 