### PR TITLE
Use Quiescence to Drive the DirectRunner

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResult.java
@@ -20,6 +20,8 @@ import com.google.auto.value.AutoValue;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 
+import java.util.Set;
+
 import javax.annotation.Nullable;
 
 /**
@@ -53,16 +55,21 @@ abstract class CommittedResult {
    * {@link CreatePCollectionView}) should explicitly set this to true. If {@link #getOutputs()}
    * returns a nonempty iterable, this will also return true.
    */
-  public abstract boolean producedOutputs();
+  public abstract Set<OutputType> getProducedOutputTypes();
 
   public static CommittedResult create(
       InProcessTransformResult original,
       CommittedBundle<?> unprocessedElements,
       Iterable<? extends CommittedBundle<?>> outputs,
-      boolean producedOutputs) {
+      Set<OutputType> producedOutputs) {
     return new AutoValue_CommittedResult(original.getTransform(),
         unprocessedElements,
         outputs,
         producedOutputs);
+  }
+
+  enum OutputType {
+    PCOLLECTION_VIEW,
+    BUNDLE
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResult.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
+
 import com.google.auto.value.AutoValue;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
@@ -45,12 +46,23 @@ abstract class CommittedResult {
    */
   public abstract Iterable<? extends CommittedBundle<?>> getOutputs();
 
+  /**
+   * Returns if the transform that produced this result produced outputs.
+   *
+   * <p>Transforms that produce output via modifying the state of the runner (e.g.
+   * {@link CreatePCollectionView}) should explicitly set this to true. If {@link #getOutputs()}
+   * returns a nonempty iterable, this will also return true.
+   */
+  public abstract boolean producedOutputs();
+
   public static CommittedResult create(
       InProcessTransformResult original,
       CommittedBundle<?> unprocessedElements,
-      Iterable<? extends CommittedBundle<?>> outputs) {
+      Iterable<? extends CommittedBundle<?>> outputs,
+      boolean producedOutputs) {
     return new AutoValue_CommittedResult(original.getTransform(),
         unprocessedElements,
-        outputs);
+        outputs,
+        producedOutputs);
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CompletionCallback.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CompletionCallback.java
@@ -16,6 +16,7 @@
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
+import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 
 /**
  * A callback for completing a bundle of input.
@@ -29,8 +30,10 @@ interface CompletionCallback {
 
   /**
    * Handle an input bundle that did not require processing.
+   *
+   * <p>This occurs when a Source has no splits that can currently produce outputs.
    */
-  void handleEmpty(CommittedBundle<?> inputBundle);
+  void handleEmpty(AppliedPTransform<?, ?, ?> transform);
 
   /**
    * Handle a result that terminated abnormally due to the provided {@link Throwable}.

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CompletionCallback.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CompletionCallback.java
@@ -28,6 +28,11 @@ interface CompletionCallback {
       CommittedBundle<?> inputBundle, InProcessTransformResult result);
 
   /**
+   * Handle an input bundle that did not require processing.
+   */
+  void handleEmpty(CommittedBundle<?> inputBundle);
+
+  /**
    * Handle a result that terminated abnormally due to the provided {@link Throwable}.
    */
   void handleThrowable(CommittedBundle<?> inputBundle, Throwable t);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
@@ -118,7 +118,8 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
     this.visibleUpdates = new ArrayBlockingQueue<>(20);
 
     parallelExecutorService = TransformExecutorServices.parallel(executorService);
-    defaultCompletionCallback = new DefaultCompletionCallback();
+    defaultCompletionCallback =
+        new TimerIterableCompletionCallback(Collections.<TimerData>emptyList());
   }
 
   private CacheLoader<StepAndKey, TransformExecutorService>
@@ -213,18 +214,19 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
   /**
    * The base implementation of {@link CompletionCallback} that provides implementations for
    * {@link #handleResult(CommittedBundle, InProcessTransformResult)} and
-   * {@link #handleThrowable(CommittedBundle, Throwable)}, given an implementation of
-   * {@link #getCommittedResult(CommittedBundle, InProcessTransformResult)}.
+   * {@link #handleThrowable(CommittedBundle, Throwable)}.
    */
-  private abstract class CompletionCallbackBase implements CompletionCallback {
-    protected abstract CommittedResult getCommittedResult(
-        CommittedBundle<?> inputBundle,
-        InProcessTransformResult result);
+  private class TimerIterableCompletionCallback implements CompletionCallback {
+    private final Iterable<TimerData> timers;
+
+    protected TimerIterableCompletionCallback(Iterable<TimerData> timers) {
+      this.timers = timers;
+    }
 
     @Override
     public final CommittedResult handleResult(
         CommittedBundle<?> inputBundle, InProcessTransformResult result) {
-      CommittedResult committedResult = getCommittedResult(inputBundle, result);
+      CommittedResult committedResult = evaluationContext.handleResult(inputBundle, timers, result);
       for (CommittedBundle<?> outputBundle : committedResult.getOutputs()) {
         allUpdates.offer(ExecutorUpdate.fromBundle(outputBundle,
             valueToConsumers.get(outputBundle.getPCollection())));
@@ -238,46 +240,14 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
     }
 
     @Override
+    public void handleEmpty(CommittedBundle<?> inputBundle) {
+    }
+
+    @Override
     public final void handleThrowable(CommittedBundle<?> inputBundle, Throwable t) {
       allUpdates.offer(ExecutorUpdate.fromThrowable(t));
     }
   }
-
-  /**
-   * The default {@link CompletionCallback}. The default completion callback is used to complete
-   * transform evaluations that are triggered due to the arrival of elements from an upstream
-   * transform, or for a source transform.
-   */
-  private class DefaultCompletionCallback extends CompletionCallbackBase {
-    @Override
-    public CommittedResult getCommittedResult(
-        CommittedBundle<?> inputBundle, InProcessTransformResult result) {
-      return evaluationContext.handleResult(inputBundle,
-          Collections.<TimerData>emptyList(),
-          result);
-    }
-  }
-
-  /**
-   * A {@link CompletionCallback} where the completed bundle was produced to deliver some collection
-   * of {@link TimerData timers}. When the evaluator completes successfully, reports all of the
-   * timers used to create the input to the {@link InProcessEvaluationContext evaluation context}
-   * as part of the result.
-   */
-  private class TimerCompletionCallback extends CompletionCallbackBase {
-    private final Iterable<TimerData> timers;
-
-    private TimerCompletionCallback(Iterable<TimerData> timers) {
-      this.timers = timers;
-    }
-
-    @Override
-    public CommittedResult getCommittedResult(
-        CommittedBundle<?> inputBundle, InProcessTransformResult result) {
-          return evaluationContext.handleResult(inputBundle, timers, result);
-    }
-  }
-
   /**
    * An internal status update on the state of the executor.
    *
@@ -420,7 +390,7 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
                           null, keyTimers.getKey(), (PCollection) transform.getInput())
                       .add(WindowedValue.valueInEmptyWindows(work))
                       .commit(evaluationContext.now());
-              scheduleConsumption(transform, bundle, new TimerCompletionCallback(delivery));
+              scheduleConsumption(transform, bundle, new TimerIterableCompletionCallback(delivery));
               firedTimers = true;
             }
           }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
@@ -50,6 +50,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
@@ -80,6 +82,18 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
   private final CompletionCallback defaultCompletionCallback;
 
   private Collection<AppliedPTransform<?, ?, ?>> rootNodes;
+
+ private final AtomicReference<ExecutorState> state =
+      new AtomicReference<>(ExecutorState.QUIESCENT);
+
+  /**
+   * Measures the number of {@link TransformExecutor TransformExecutors} that have been scheduled
+   * but not yet completed.
+   *
+   * <p>Before a {@link TransformExecutor} is scheduled, this value is incremented. All methods in
+   * {@link CompletionCallback} decrement this value.
+   */
+  private final AtomicLong outstandingWork = new AtomicLong();
 
   public static ExecutorServiceParallelExecutor create(
       ExecutorService executorService,
@@ -180,6 +194,7 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
             transform,
             onComplete,
             transformExecutor);
+    outstandingWork.incrementAndGet();
     transformExecutor.schedule(callable);
   }
 
@@ -236,16 +251,22 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
         allUpdates.offer(ExecutorUpdate.fromBundle(unprocessedInputs,
             Collections.<AppliedPTransform<?, ?, ?>>singleton(committedResult.getTransform())));
       }
+      if (!committedResult.getProducedOutputTypes().isEmpty()) {
+        state.set(ExecutorState.ACTIVE);
+      }
+      outstandingWork.decrementAndGet();
       return committedResult;
     }
 
     @Override
-    public void handleEmpty(CommittedBundle<?> inputBundle) {
+    public void handleEmpty(AppliedPTransform<?, ?, ?> transform) {
+      outstandingWork.decrementAndGet();
     }
 
     @Override
     public final void handleThrowable(CommittedBundle<?> inputBundle, Throwable t) {
       allUpdates.offer(ExecutorUpdate.fromThrowable(t));
+      outstandingWork.decrementAndGet();
     }
   }
   /**
@@ -325,6 +346,20 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
       String oldName = Thread.currentThread().getName();
       Thread.currentThread().setName(runnableName);
       try {
+        boolean noWorkOutstanding = outstandingWork.get() == 0L;
+        ExecutorState startingState = state.get();
+        if (startingState == ExecutorState.ACTIVE) {
+          // The remainder of this call will add all available work to the Executor, and there will
+          // be no new work available
+          state.compareAndSet(ExecutorState.ACTIVE, ExecutorState.PROCESSING);
+        } else if (startingState == ExecutorState.PROCESSING && noWorkOutstanding) {
+          // The executor has consumed all new work and no new work was added
+          state.compareAndSet(ExecutorState.PROCESSING, ExecutorState.QUIESCING);
+        } else if (startingState == ExecutorState.QUIESCING && noWorkOutstanding) {
+          // The executor re-ran all blocked work and nothing could make progress.
+          state.compareAndSet(ExecutorState.QUIESCING, ExecutorState.QUIESCENT);
+        }
+        fireTimers();
         Collection<ExecutorUpdate> updates = new ArrayList<>();
         // Pull all available updates off of the queue before adding additional work. This ensures
         // both loops terminate.
@@ -336,14 +371,18 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
         for (ExecutorUpdate update : updates) {
           LOG.debug("Executor Update: {}", update);
           if (update.getBundle().isPresent()) {
-            scheduleConsumers(update);
+            if (ExecutorState.ACTIVE == startingState || (ExecutorState.PROCESSING == startingState
+                && noWorkOutstanding)) {
+              scheduleConsumers(update);
+            } else {
+              allUpdates.offer(update);
+            }
           } else if (update.getException().isPresent()) {
             visibleUpdates.offer(VisibleExecutorUpdate.fromThrowable(update.getException().get()));
             exceptionThrown = true;
           }
         }
-        boolean timersFired = fireTimers();
-        addWorkIfNecessary(timersFired);
+        addWorkIfNecessary();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         LOG.error("Monitor died due to being interrupted");
@@ -367,9 +406,8 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
     /**
      * Fires any available timers. Returns true if at least one timer was fired.
      */
-    private boolean fireTimers() throws Exception {
+    private void fireTimers() throws Exception {
       try {
-        boolean firedTimers = false;
         for (Map.Entry<
                AppliedPTransform<?, ?, ?>, Map<StructuralKey<?>, FiredTimers>> transformTimers :
             evaluationContext.extractFiredTimers().entrySet()) {
@@ -390,12 +428,11 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
                           null, keyTimers.getKey(), (PCollection) transform.getInput())
                       .add(WindowedValue.valueInEmptyWindows(work))
                       .commit(evaluationContext.now());
+              state.set(ExecutorState.ACTIVE);
               scheduleConsumption(transform, bundle, new TimerIterableCompletionCallback(delivery));
-              firedTimers = true;
             }
           }
         }
-        return firedTimers;
       } catch (Exception e) {
         LOG.error("Internal Error while delivering timers", e);
         throw e;
@@ -421,18 +458,56 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
      * add more work from root nodes that may have additional work. This ensures that if a pipeline
      * has elements available from the root nodes it will add those elements when necessary.
      */
-    private void addWorkIfNecessary(boolean firedTimers) {
+    private void addWorkIfNecessary() {
       // If any timers have fired, they will add more work; We don't need to add more
-      if (firedTimers) {
-        return;
-      }
-      // All current TransformExecutors are blocked; add more work from the roots.
-      for (AppliedPTransform<?, ?, ?> root : rootNodes) {
-        if (!evaluationContext.isDone(root)) {
-          scheduleConsumption(root, null, defaultCompletionCallback);
+      if (state.get() == ExecutorState.QUIESCENT) {
+        // All current TransformExecutors are blocked; add more work from the roots.
+        for (AppliedPTransform<?, ?, ?> root : rootNodes) {
+          if (!evaluationContext.isDone(root)) {
+            scheduleConsumption(root, null, defaultCompletionCallback);
+            state.set(ExecutorState.ACTIVE);
+          }
         }
       }
     }
+  }
+
+
+  /**
+   * The state of the executor. The state of the executor determines the behavior of the
+   * {@link MonitorRunnable} when it runs.
+   */
+  private enum ExecutorState {
+    /**
+     * Output has been produced since the last time the monitor ran. Work exists that has not yet
+     * been evaluated, and all pending, including potentially blocked work, should be evaluated.
+     *
+     * <p>The executor becomes active whenever a timer fires, a {@link PCollectionView} is updated,
+     * or output is produced by the evaluation of a {@link TransformExecutor}.
+     */
+    ACTIVE,
+    /**
+     * The Executor does not have any unevaluated work available to it, but work is in progress.
+     * Work should not be added until the Executor becomes active or no work is outstanding.
+     *
+     * <p>If all outstanding work completes without the executor becoming {@code ACTIVE}, the
+     * Executor enters state {@code QUIESCING}. Previously evaluated work must be reevaluated, in
+     * case a side input has made progress.
+     */
+    PROCESSING,
+    /**
+     * All outstanding work is work that may be blocked on a side input. When there is no
+     * outstanding work, the executor becomes {@code QUIESCENT}.
+     */
+    QUIESCING,
+    /**
+     * All elements are either buffered in state or are blocked on a side input. There are no
+     * timers that are permitted to fire but have not. There is no outstanding work.
+     *
+     * <p>The pipeline will not make progress without the progression of watermarks, the progression
+     * of processing time, or the addition of elements.
+     */
+    QUIESCENT
   }
 }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -159,7 +159,8 @@ class InProcessEvaluationContext {
         completedBundle == null
             ? null
             : completedBundle.withElements((Iterable) result.getUnprocessedElements()),
-        committedBundles);
+        committedBundles,
+        result.producedOutput());
     watermarkManager.updateWatermarks(
         completedBundle,
         result.getTimerUpdate().withCompletedTimers(completedTimers),

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -18,6 +18,7 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.runners.inprocess.CommittedResult.OutputType;
 import com.google.cloud.dataflow.sdk.runners.inprocess.GroupByKeyEvaluatorFactory.InProcessGroupByKeyOnly;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.FiredTimers;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TransformWatermarks;
@@ -44,15 +45,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
-
 import org.joda.time.Instant;
-
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import javax.annotation.Nullable;
 
 /**
@@ -155,12 +154,18 @@ class InProcessEvaluationContext {
     Iterable<? extends CommittedBundle<?>> committedBundles =
         commitBundles(result.getOutputBundles());
     // Update watermarks and timers
+    EnumSet<OutputType> outputTypes = EnumSet.copyOf(result.getOutputTypes());
+    if (Iterables.isEmpty(committedBundles)) {
+      outputTypes.remove(OutputType.BUNDLE);
+    } else {
+      outputTypes.add(OutputType.BUNDLE);
+    }
     CommittedResult committedResult = CommittedResult.create(result,
         completedBundle == null
             ? null
             : completedBundle.withElements((Iterable) result.getUnprocessedElements()),
         committedBundles,
-        result.producedOutput());
+        outputTypes);
     watermarkManager.updateWatermarks(
         completedBundle,
         result.getTimerUpdate().withCompletedTimers(completedTimers),

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
@@ -79,4 +79,11 @@ interface InProcessTransformResult {
    * <p>If this evaluation did not add or remove any timers, returns an empty TimerUpdate.
    */
   TimerUpdate getTimerUpdate();
+
+  /**
+   * Returns whether output was produced by the evaluation of this transform. True if
+   * {@link #getOutputBundles()} is nonempty, or if pipeline-visible state has changed (for example,
+   * the contents of a {@link PCollectionView} were updated).
+   */
+  boolean producedOutput();
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessTransformResult.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
+import com.google.cloud.dataflow.sdk.runners.inprocess.CommittedResult.OutputType;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
@@ -23,9 +24,8 @@ import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.cloud.dataflow.sdk.util.common.CounterSet;
 import com.google.cloud.dataflow.sdk.util.state.CopyOnAccessInMemoryStateInternals;
-
 import org.joda.time.Instant;
-
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -81,9 +81,8 @@ interface InProcessTransformResult {
   TimerUpdate getTimerUpdate();
 
   /**
-   * Returns whether output was produced by the evaluation of this transform. True if
-   * {@link #getOutputBundles()} is nonempty, or if pipeline-visible state has changed (for example,
-   * the contents of a {@link PCollectionView} were updated).
+   * Returns the types of output produced by this {@link PTransform}. This may not include
+   * {@link OutputType#BUNDLE}, as empty bundles may be dropped when the transform is committed.
    */
-  boolean producedOutput();
+  Set<OutputType> getOutputTypes();
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
@@ -109,6 +109,7 @@ class TransformExecutor<T> implements Runnable {
       TransformEvaluator<T> evaluator =
           evaluatorFactory.forApplication(transform, inputBundle, evaluationContext);
       if (evaluator == null) {
+        onComplete.handleEmpty(inputBundle);
         // Nothing to do
         return;
       }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
@@ -109,7 +109,7 @@ class TransformExecutor<T> implements Runnable {
       TransformEvaluator<T> evaluator =
           evaluatorFactory.forApplication(transform, inputBundle, evaluationContext);
       if (evaluator == null) {
-        onComplete.handleEmpty(inputBundle);
+        onComplete.handleEmpty(transform);
         // Nothing to do
         return;
       }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ViewEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ViewEvaluatorFactory.java
@@ -76,7 +76,9 @@ class ViewEvaluatorFactory implements TransformEvaluatorFactory {
       @Override
       public InProcessTransformResult finishBundle() {
         writer.add(elements);
-        return StepTransformResult.withoutHold(application).build();
+        return StepTransformResult.withoutHold(application)
+            .withAdditionalOutput(!elements.isEmpty())
+            .build();
       }
     };
   }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ViewEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ViewEvaluatorFactory.java
@@ -17,6 +17,7 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
 import com.google.cloud.dataflow.sdk.coders.VoidCoder;
+import com.google.cloud.dataflow.sdk.runners.inprocess.CommittedResult.OutputType;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.PCollectionViewWriter;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
@@ -29,7 +30,6 @@ import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PCollectionView;
 import com.google.cloud.dataflow.sdk.values.PInput;
 import com.google.cloud.dataflow.sdk.values.POutput;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -76,8 +76,11 @@ class ViewEvaluatorFactory implements TransformEvaluatorFactory {
       @Override
       public InProcessTransformResult finishBundle() {
         writer.add(elements);
-        return StepTransformResult.withoutHold(application)
-            .withAdditionalOutput(!elements.isEmpty())
+        StepTransformResult.Builder resultBuilder = StepTransformResult.withoutHold(application);
+        if (!elements.isEmpty()) {
+          resultBuilder = resultBuilder.withAdditionalOutput(OutputType.PCOLLECTION_VIEW);
+        }
+        return resultBuilder
             .build();
       }
     };

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResultTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResultTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.google.cloud.dataflow.sdk.runners.inprocess.CommittedResult.OutputType;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.transforms.Create;
@@ -28,15 +29,14 @@ import com.google.cloud.dataflow.sdk.values.PBegin;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PDone;
 import com.google.common.collect.ImmutableList;
-
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -58,7 +58,7 @@ public class CommittedResultTest implements Serializable {
             StepTransformResult.withoutHold(transform).build(),
             bundleFactory.createRootBundle(created).commit(Instant.now()),
             Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList(),
-            false);
+            EnumSet.noneOf(OutputType.class));
 
     assertThat(result.getTransform(), Matchers.<AppliedPTransform<?, ?, ?>>equalTo(transform));
   }
@@ -74,7 +74,7 @@ public class CommittedResultTest implements Serializable {
             StepTransformResult.withoutHold(transform).build(),
             bundle,
             Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList(),
-            false);
+            EnumSet.noneOf(OutputType.class));
 
     assertThat(result.getUnprocessedInputs(),
         Matchers.<InProcessPipelineRunner.CommittedBundle<?>>equalTo(bundle));
@@ -87,7 +87,7 @@ public class CommittedResultTest implements Serializable {
             StepTransformResult.withoutHold(transform).build(),
             null,
             Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList(),
-            false);
+            EnumSet.noneOf(OutputType.class));
 
     assertThat(result.getUnprocessedInputs(), nullValue());
   }
@@ -106,7 +106,7 @@ public class CommittedResultTest implements Serializable {
             StepTransformResult.withoutHold(transform).build(),
             bundleFactory.createRootBundle(created).commit(Instant.now()),
             outputs,
-            true);
+            EnumSet.of(OutputType.BUNDLE, OutputType.PCOLLECTION_VIEW));
 
     assertThat(result.getOutputs(), Matchers.containsInAnyOrder(outputs.toArray()));
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResultTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/CommittedResultTest.java
@@ -54,9 +54,11 @@ public class CommittedResultTest implements Serializable {
   @Test
   public void getTransformExtractsFromResult() {
     CommittedResult result =
-        CommittedResult.create(StepTransformResult.withoutHold(transform).build(),
+        CommittedResult.create(
+            StepTransformResult.withoutHold(transform).build(),
             bundleFactory.createRootBundle(created).commit(Instant.now()),
-            Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList());
+            Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList(),
+            false);
 
     assertThat(result.getTransform(), Matchers.<AppliedPTransform<?, ?, ?>>equalTo(transform));
   }
@@ -68,9 +70,11 @@ public class CommittedResultTest implements Serializable {
             .add(WindowedValue.valueInGlobalWindow(2))
             .commit(Instant.now());
     CommittedResult result =
-        CommittedResult.create(StepTransformResult.withoutHold(transform).build(),
+        CommittedResult.create(
+            StepTransformResult.withoutHold(transform).build(),
             bundle,
-            Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList());
+            Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList(),
+            false);
 
     assertThat(result.getUnprocessedInputs(),
         Matchers.<InProcessPipelineRunner.CommittedBundle<?>>equalTo(bundle));
@@ -79,9 +83,11 @@ public class CommittedResultTest implements Serializable {
   @Test
   public void getUncommittedElementsNull() {
     CommittedResult result =
-        CommittedResult.create(StepTransformResult.withoutHold(transform).build(),
+        CommittedResult.create(
+            StepTransformResult.withoutHold(transform).build(),
             null,
-            Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList());
+            Collections.<InProcessPipelineRunner.CommittedBundle<?>>emptyList(),
+            false);
 
     assertThat(result.getUnprocessedInputs(), nullValue());
   }
@@ -96,9 +102,11 @@ public class CommittedResultTest implements Serializable {
                 WindowingStrategy.globalDefault(),
                 PCollection.IsBounded.UNBOUNDED)).commit(Instant.now()));
     CommittedResult result =
-        CommittedResult.create(StepTransformResult.withoutHold(transform).build(),
+        CommittedResult.create(
+            StepTransformResult.withoutHold(transform).build(),
             bundleFactory.createRootBundle(created).commit(Instant.now()),
-            outputs);
+            outputs,
+            true);
 
     assertThat(result.getOutputs(), Matchers.containsInAnyOrder(outputs.toArray()));
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
@@ -54,6 +54,7 @@ import com.google.cloud.dataflow.sdk.values.PCollectionList;
 import com.google.cloud.dataflow.sdk.values.PValue;
 import com.google.cloud.dataflow.sdk.values.TimestampedValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -1418,8 +1419,10 @@ public class InMemoryWatermarkManagerTest implements Serializable {
       AppliedPTransform<?, ?, ?> transform,
       @Nullable CommittedBundle<?> unprocessedBundle,
       Iterable<? extends CommittedBundle<?>> bundles) {
-    return CommittedResult.create(StepTransformResult.withoutHold(transform).build(),
+    return CommittedResult.create(
+        StepTransformResult.withoutHold(transform).build(),
         unprocessedBundle,
-        bundles);
+        bundles,
+        !Iterables.isEmpty(bundles));
   }
 }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManagerTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThat;
 import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
 import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
 import com.google.cloud.dataflow.sdk.coders.VarLongCoder;
+import com.google.cloud.dataflow.sdk.runners.inprocess.CommittedResult.OutputType;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.FiredTimers;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.TimerUpdate.TimerUpdateBuilder;
@@ -55,7 +56,6 @@ import com.google.cloud.dataflow.sdk.values.PValue;
 import com.google.cloud.dataflow.sdk.values.TimestampedValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -65,13 +65,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -1423,6 +1422,8 @@ public class InMemoryWatermarkManagerTest implements Serializable {
         StepTransformResult.withoutHold(transform).build(),
         unprocessedBundle,
         bundles,
-        !Iterables.isEmpty(bundles));
+        Iterables.isEmpty(bundles)
+            ? EnumSet.noneOf(OutputType.class)
+            : EnumSet.of(OutputType.BUNDLE));
   }
 }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepTransformResultTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/StepTransformResultTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
+import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link StepTransformResult}.
+ */
+@RunWith(JUnit4.class)
+public class StepTransformResultTest {
+  private AppliedPTransform<?, ?, ?> transform;
+  private BundleFactory bundleFactory;
+  private PCollection<Integer> pc;
+
+  @Before
+  public void setup() {
+    TestPipeline p = TestPipeline.create();
+    pc = p.apply(Create.of(1, 2, 3));
+    transform = pc.getProducingTransformInternal();
+
+    bundleFactory = InProcessBundleFactory.create();
+  }
+
+  @Test
+  public void producedBundlesProducedOutputs() {
+    InProcessTransformResult result = StepTransformResult.withoutHold(transform)
+        .addOutput(bundleFactory.createRootBundle(pc))
+        .build();
+
+    assertThat(result.producedOutput(), is(true));
+  }
+
+  @Test
+  public void withAdditionalOutputProducedOutputs() {
+    InProcessTransformResult result =
+        StepTransformResult.withoutHold(transform).withAdditionalOutput(true).build();
+
+    assertThat(result.producedOutput(), is(true));
+  }
+
+  @Test
+  public void producedBundlesAndAdditionalOutputProducedOutputs() {
+    InProcessTransformResult result = StepTransformResult.withoutHold(transform)
+        .addOutput(bundleFactory.createRootBundle(pc))
+        .withAdditionalOutput(true)
+        .build();
+
+    assertThat(result.producedOutput(), is(true));
+  }
+
+  @Test
+  public void noBundlesNoAdditionalOutputProducedOutputsFalse() {
+    InProcessTransformResult result = StepTransformResult.withoutHold(transform).build();
+
+    assertThat(result.producedOutput(), is(false));
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
@@ -131,6 +131,26 @@ public class TransformExecutorTest {
   }
 
   @Test
+  public void nullTransformEvaluatorTerminates() throws Exception {
+    when(registry.forApplication(created.getProducingTransformInternal(),
+        null,
+        evaluationContext)).thenReturn(null);
+
+    TransformExecutor<Object> executor = TransformExecutor.create(registry,
+        Collections.<ModelEnforcementFactory>emptyList(),
+        evaluationContext,
+        null,
+        created.getProducingTransformInternal(),
+        completionCallback,
+        transformEvaluationState);
+    executor.run();
+
+    assertThat(completionCallback.handledResult, is(nullValue()));
+    assertThat(completionCallback.handledEmpty, equalTo(true));
+    assertThat(completionCallback.handledThrowable, is(nullValue()));
+  }
+
+  @Test
   public void inputBundleProcessesEachElementFinishesAndCompletes() throws Exception {
     final InProcessTransformResult result =
         StepTransformResult.withoutHold(downstream.getProducingTransformInternal()).build();
@@ -468,6 +488,7 @@ public class TransformExecutorTest {
 
   private static class RegisteringCompletionCallback implements CompletionCallback {
     private InProcessTransformResult handledResult = null;
+    private boolean handledEmpty = false;
     private Throwable handledThrowable = null;
     private final CountDownLatch onMethod;
 
@@ -490,6 +511,12 @@ public class TransformExecutorTest {
       return CommittedResult.create(result,
           unprocessedBundle,
           Collections.<CommittedBundle<?>>emptyList());
+    }
+
+    @Override
+    public void handleEmpty(CommittedBundle<?> inputBundle) {
+      handledEmpty = true;
+      onMethod.countDown();
     }
 
     @Override

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
@@ -508,9 +508,8 @@ public class TransformExecutorTest {
 
       CommittedBundle<?> unprocessedBundle =
           inputBundle == null ? null : inputBundle.withElements(unprocessedElements);
-      return CommittedResult.create(result,
-          unprocessedBundle,
-          Collections.<CommittedBundle<?>>emptyList());
+      return CommittedResult.create(
+          result, unprocessedBundle, Collections.<CommittedBundle<?>>emptyList(), false);
     }
 
     @Override

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.dataflow.sdk.coders.ByteArrayCoder;
+import com.google.cloud.dataflow.sdk.runners.inprocess.CommittedResult.OutputType;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
@@ -37,7 +38,6 @@ import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.common.util.concurrent.MoreExecutors;
-
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
 import org.junit.Before;
@@ -48,15 +48,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 
 /**
  * Tests for {@link TransformExecutor}.
@@ -508,12 +509,14 @@ public class TransformExecutorTest {
 
       CommittedBundle<?> unprocessedBundle =
           inputBundle == null ? null : inputBundle.withElements(unprocessedElements);
-      return CommittedResult.create(
-          result, unprocessedBundle, Collections.<CommittedBundle<?>>emptyList(), false);
+      return CommittedResult.create(result,
+          unprocessedBundle,
+          Collections.<CommittedBundle<?>>emptyList(),
+          EnumSet.noneOf(OutputType.class));
     }
 
     @Override
-    public void handleEmpty(CommittedBundle<?> inputBundle) {
+    public void handleEmpty(AppliedPTransform<?, ?, ?> transform) {
       handledEmpty = true;
       onMethod.countDown();
     }


### PR DESCRIPTION
The Executor should add work whenever it becomes Quiescent.

Track the amount of outstanding work in the executor, and
modify the state appropriately whenever work is scheduled or completes.

Backports https://github.com/apache/incubator-beam/pull/754