### PR TITLE
Add the TestStream Primitive

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedMultiset;
 import com.google.common.collect.TreeMultiset;
+import org.joda.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,7 +56,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
-import org.joda.time.Instant;
 
 /**
  * Manages watermarks of {@link PCollection PCollections} and input and output watermarks of

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
@@ -39,9 +39,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedMultiset;
 import com.google.common.collect.TreeMultiset;
-
-import org.joda.time.Instant;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -57,8 +54,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.annotation.Nullable;
+import org.joda.time.Instant;
 
 /**
  * Manages watermarks of {@link PCollection PCollections} and input and output watermarks of
@@ -1133,19 +1130,12 @@ class InMemoryWatermarkManager {
     private Map<StructuralKey<?>, FiredTimers> extractFiredTimers() {
       Map<StructuralKey<?>, List<TimerData>> eventTimeTimers =
           inputWatermark.extractFiredEventTimeTimers();
-      Map<StructuralKey<?>, List<TimerData>> processingTimers;
-      Map<StructuralKey<?>, List<TimerData>> synchronizedTimers;
-      if (inputWatermark.get().equals(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
-        processingTimers = synchronizedProcessingInputWatermark.extractFiredDomainTimers(
-            TimeDomain.PROCESSING_TIME, BoundedWindow.TIMESTAMP_MAX_VALUE);
-        synchronizedTimers = synchronizedProcessingInputWatermark.extractFiredDomainTimers(
-            TimeDomain.PROCESSING_TIME, BoundedWindow.TIMESTAMP_MAX_VALUE);
-      } else {
-        processingTimers = synchronizedProcessingInputWatermark.extractFiredDomainTimers(
-            TimeDomain.PROCESSING_TIME, clock.now());
-        synchronizedTimers = synchronizedProcessingInputWatermark.extractFiredDomainTimers(
-            TimeDomain.SYNCHRONIZED_PROCESSING_TIME, getSynchronizedProcessingInputTime());
-      }
+      Map<StructuralKey<?>, List<TimerData>> processingTimers =
+          synchronizedProcessingInputWatermark.extractFiredDomainTimers(TimeDomain.PROCESSING_TIME,
+              clock.now());
+      Map<StructuralKey<?>, List<TimerData>> synchronizedTimers =
+          synchronizedProcessingInputWatermark.extractFiredDomainTimers(
+          TimeDomain.SYNCHRONIZED_PROCESSING_TIME, getSynchronizedProcessingInputTime());
       Map<StructuralKey<?>, Map<TimeDomain, List<TimerData>>> groupedTimers = new HashMap<>();
       groupFiredTimers(groupedTimers, eventTimeTimers, processingTimers, synchronizedTimers);
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -97,24 +97,26 @@ class InProcessEvaluationContext {
 
   public static InProcessEvaluationContext create(
       InProcessPipelineOptions options,
+      Clock clock,
       BundleFactory bundleFactory,
       Collection<AppliedPTransform<?, ?, ?>> rootTransforms,
       Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers,
       Map<AppliedPTransform<?, ?, ?>, String> stepNames,
       Collection<PCollectionView<?>> views) {
     return new InProcessEvaluationContext(
-        options, bundleFactory, rootTransforms, valueToConsumers, stepNames, views);
+        options, clock, bundleFactory, rootTransforms, valueToConsumers, stepNames, views);
   }
 
   private InProcessEvaluationContext(
       InProcessPipelineOptions options,
+      Clock clock,
       BundleFactory bundleFactory,
       Collection<AppliedPTransform<?, ?, ?>> rootTransforms,
       Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers,
       Map<AppliedPTransform<?, ?, ?>, String> stepNames,
       Collection<PCollectionView<?>> views) {
     this.options = checkNotNull(options);
-    this.clock = options.getClock();
+    this.clock = clock;
     this.bundleFactory = checkNotNull(bundleFactory);
     checkNotNull(rootTransforms);
     checkNotNull(valueToConsumers);
@@ -433,5 +435,9 @@ class InProcessEvaluationContext {
 
   public Instant now() {
     return clock.now();
+  }
+
+  Clock getClock() {
+    return clock;
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineOptions.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineOptions.java
@@ -15,17 +15,13 @@
  */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
-import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.options.ApplicationNameOptions;
 import com.google.cloud.dataflow.sdk.options.Default;
 import com.google.cloud.dataflow.sdk.options.Description;
 import com.google.cloud.dataflow.sdk.options.Hidden;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
-import com.google.cloud.dataflow.sdk.options.Validation.Required;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -37,17 +33,12 @@ public interface InProcessPipelineOptions extends PipelineOptions, ApplicationNa
    * Gets the {@link ExecutorServiceFactory} to use to create instances of {@link ExecutorService}
    * to execute {@link PTransform PTransforms}.
    *
-   * <p>Note that {@link ExecutorService ExecutorServices} returned by the factory must ensure that
-   * it cannot enter a state in which it will not schedule additional pending work unless currently
-   * scheduled work completes, as this may cause the {@link Pipeline} to cease processing.
-   *
    * <p>Defaults to a {@link FixedThreadPoolExecutorServiceFactory}, which produces instances of
    * {@link Executors#newCachedThreadPool()}.
    */
+  @Deprecated
   @JsonIgnore
-  @Required
   @Hidden
-  @Default.InstanceFactory(FixedThreadPoolExecutorServiceFactory.class)
   ExecutorServiceFactory getExecutorServiceFactory();
 
   void setExecutorServiceFactory(ExecutorServiceFactory executorService);
@@ -56,9 +47,8 @@ public interface InProcessPipelineOptions extends PipelineOptions, ApplicationNa
    * Gets the {@link Clock} used by this pipeline. The clock is used in place of accessing the
    * system time when time values are required by the evaluator.
    */
-  @Default.InstanceFactory(NanosOffsetClock.Factory.class)
+  @Deprecated
   @JsonIgnore
-  @Required
   @Hidden
   @Description(
       "The processing time source used by the pipeline. When the current time is "

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineOptions.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineOptions.java
@@ -35,6 +35,8 @@ public interface InProcessPipelineOptions extends PipelineOptions, ApplicationNa
    *
    * <p>Defaults to a {@link FixedThreadPoolExecutorServiceFactory}, which produces instances of
    * {@link Executors#newCachedThreadPool()}.
+   *
+   * @deprecated the runner manages its own {@link ExecutorService} as an implementation detail
    */
   @Deprecated
   @JsonIgnore
@@ -46,6 +48,8 @@ public interface InProcessPipelineOptions extends PipelineOptions, ApplicationNa
   /**
    * Gets the {@link Clock} used by this pipeline. The clock is used in place of accessing the
    * system time when time values are required by the evaluator.
+   *
+   * @deprecated the runner manages its own {@link Clock} as an implementation detail
    */
   @Deprecated
   @JsonIgnore

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -55,12 +55,12 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.joda.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.joda.time.Instant;
 
 /**
  * An In-Memory implementation of the Dataflow Programming Model. Supports Unbounded

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -55,12 +55,12 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.joda.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.joda.time.Instant;
 
 /**
  * An In-Memory implementation of the Dataflow Programming Model. Supports Unbounded

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/KeyedResourcePool.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/KeyedResourcePool.java
@@ -1,0 +1,30 @@
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import com.google.common.base.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A pool of resources associated with specific keys. Implementations enforce specific use patterns,
+ * such as limiting the the number of outstanding elements available per key.
+ */
+interface KeyedResourcePool<K, V> {
+  /**
+   * Tries to acquire a value for the provided key, loading it via the provided loader if necessary.
+   *
+   * <p>If the returned {@link Optional} contains a value, the caller obtains ownership of that
+   * value. The value should be released back to this {@link KeyedResourcePool} after the
+   * caller no longer has use of it using {@link #release(Object, Object)}.
+   *
+   * <p>The provided {@link Callable} <b>must not</b> return null; it may either return a non-null
+   * value or throw an exception.
+   */
+  Optional<V> tryAcquire(K key, Callable<V> loader) throws ExecutionException;
+
+  /**
+   * Release the provided value, relinquishing ownership of it. Future calls to
+   * {@link #tryAcquire(Object, Callable)} may return the released value.
+   */
+  void release(K key, V value);
+}
+

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/KeyedResourcePool.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/KeyedResourcePool.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import com.google.common.base.Optional;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePool.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePool.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePool.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePool.java
@@ -1,0 +1,78 @@
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A {@link KeyedResourcePool} which is limited to at most one outstanding instance at a time for
+ * each key.
+ */
+class LockedKeyedResourcePool<K, V> implements KeyedResourcePool<K, V> {
+  /**
+   * A map from each key to an {@link Optional} of the associated value. At most one value is stored
+   * per key, and it is obtained by at most one thread at a time.
+   *
+   * <p>For each key in this map:
+   *
+   * <ul>
+   * <li>If there is no associated value, then no value has been stored yet.
+   * <li>If the value is {@code Optional.absent()} then the value is currently in use.
+   * <li>If the value is {@code Optional.present()} then the contained value is available for use.
+   * </ul>
+   */
+  public static <K, V> LockedKeyedResourcePool<K, V> create() {
+    return new LockedKeyedResourcePool<>();
+  }
+
+  private final ConcurrentMap<K, Optional<V>> cache;
+
+  private LockedKeyedResourcePool() {
+    cache = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public Optional<V> tryAcquire(K key, Callable<V> loader) throws ExecutionException {
+    Optional<V> value = cache.replace(key, Optional.<V>absent());
+    if (value == null) {
+      // No value already existed, so populate the cache with the value returned by the loader
+      cache.putIfAbsent(key, Optional.of(load(loader)));
+      // Some other thread may obtain the result after the putIfAbsent, so retry acquisition
+      value = cache.replace(key, Optional.<V>absent());
+    }
+    return value;
+  }
+
+  private V load(Callable<V> loader) throws ExecutionException {
+    try {
+      return loader.call();
+    } catch (Error t) {
+      throw new ExecutionError(t);
+    } catch (RuntimeException e) {
+      throw new UncheckedExecutionException(e);
+    } catch (Exception e) {
+      throw new ExecutionException(e);
+    }
+  }
+
+  @Override
+  public void release(K key, V value) {
+    Optional<V> replaced = cache.replace(key, Optional.of(value));
+    checkNotNull(replaced, "Tried to release before a value was acquired");
+    checkState(
+        !replaced.isPresent(),
+        "Released a value to a %s where there is already a value present for key %s (%s). "
+            + "At most one value may be present at a time.",
+        LockedKeyedResourcePool.class.getSimpleName(),
+        key,
+        replaced);
+  }
+}
+

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/NanosOffsetClock.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/NanosOffsetClock.java
@@ -15,11 +15,7 @@
  */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
-import com.google.cloud.dataflow.sdk.options.DefaultValueFactory;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
-
 import org.joda.time.Instant;
-
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,16 +39,6 @@ public class NanosOffsetClock implements Clock {
     return new Instant(
         baseMillis + (TimeUnit.MILLISECONDS.convert(
             System.nanoTime() - nanosAtBaseMillis, TimeUnit.NANOSECONDS)));
-  }
-
-  /**
-   * Creates instances of {@link NanosOffsetClock}.
-   */
-  public static class Factory implements DefaultValueFactory<Clock> {
-    @Override
-    public Clock create(PipelineOptions options) {
-      return new NanosOffsetClock();
-    }
   }
 }
 

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TestStreamEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TestStreamEvaluatorFactory.java
@@ -39,13 +39,13 @@ import com.google.cloud.dataflow.sdk.values.PInput;
 import com.google.cloud.dataflow.sdk.values.POutput;
 import com.google.cloud.dataflow.sdk.values.TimestampedValue;
 import com.google.common.base.Supplier;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
-import org.joda.time.Duration;
-import org.joda.time.Instant;
 
 /** The {@link TransformEvaluatorFactory} for the {@link TestStream} primitive. */
 class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TestStreamEvaluatorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TestStreamEvaluatorFactory.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.UncommittedBundle;
+import com.google.cloud.dataflow.sdk.testing.TestStream;
+import com.google.cloud.dataflow.sdk.testing.TestStream.ElementEvent;
+import com.google.cloud.dataflow.sdk.testing.TestStream.Event;
+import com.google.cloud.dataflow.sdk.testing.TestStream.EventType;
+import com.google.cloud.dataflow.sdk.testing.TestStream.ProcessingTimeEvent;
+import com.google.cloud.dataflow.sdk.testing.TestStream.WatermarkEvent;
+import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+import com.google.cloud.dataflow.sdk.util.WindowingStrategy;
+import com.google.cloud.dataflow.sdk.values.PBegin;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PCollection.IsBounded;
+import com.google.cloud.dataflow.sdk.values.PInput;
+import com.google.cloud.dataflow.sdk.values.POutput;
+import com.google.cloud.dataflow.sdk.values.TimestampedValue;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * The {@link TransformEvaluatorFactory} for the {@link TestStream} primitive.
+ */
+class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {
+  /**
+   * At most one evaluator may be used for {@link TestStream} instances to ensure the appropriate
+   * sequence of outputs. Each evaluator is stateful and independently available.
+   */
+  private final ConcurrentMap<AppliedPTransform<?, ?, ?>, Optional<Evaluator<?>>> evaluators =
+      new ConcurrentHashMap<>();
+
+  @Nullable
+  @Override
+  public <InputT> TransformEvaluator<InputT> forApplication(
+      AppliedPTransform<?, ?, ?> application,
+      @Nullable CommittedBundle<?> inputBundle,
+      InProcessEvaluationContext evaluationContext) throws Exception {
+    return createEvaluator((AppliedPTransform) application, evaluationContext);
+  }
+
+  private <InputT, OutputT> TransformEvaluator<? super InputT> createEvaluator(
+      AppliedPTransform<PBegin, PCollection<OutputT>, TestStream<OutputT>> application,
+      InProcessEvaluationContext evaluationContext) {
+    // Replaces any existing value with absent, and get the existing value (atomically); ensures
+    // only one thread can obtain the evaluator per-transform.
+    Optional<Evaluator<?>> evaluator =
+        evaluators.replace(application, Optional.<Evaluator<?>>absent());
+    if (evaluator != null) {
+      return evaluator.orNull();
+    }
+    Evaluator<OutputT> createdEvaluator =
+        new Evaluator<>(application, evaluationContext, evaluators);
+    evaluators.putIfAbsent(application, Optional.<Evaluator<?>>of(createdEvaluator));
+    return evaluators.replace(application, Optional.<Evaluator<?>>absent()).orNull();
+  }
+
+  private static class Evaluator<T> implements TransformEvaluator<Object> {
+    private final AppliedPTransform<PBegin, PCollection<T>, TestStream<T>> application;
+    private final InProcessEvaluationContext context;
+    private final ConcurrentMap<AppliedPTransform<?, ?, ?>, Optional<Evaluator<?>>> evaluators;
+    private final List<Event<T>> events;
+    private int index;
+    private Instant currentWatermark;
+
+    private Evaluator(
+        AppliedPTransform<PBegin, PCollection<T>, TestStream<T>> application,
+        InProcessEvaluationContext context,
+        ConcurrentMap<AppliedPTransform<?, ?, ?>, Optional<Evaluator<?>>> evaluators) {
+      this.application = application;
+      this.context = context;
+      this.events = application.getTransform().getEvents();
+      this.evaluators = evaluators;
+      index = 0;
+      currentWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE;
+    }
+
+    @Override
+    public void processElement(WindowedValue<Object> element) throws Exception {
+    }
+
+    @Override
+    public InProcessTransformResult finishBundle() throws Exception {
+      if (index >= events.size()) {
+        return StepTransformResult.withHold(application, BoundedWindow.TIMESTAMP_MAX_VALUE).build();
+      }
+      Event<T> event = events.get(index);
+      if (event.getType().equals(EventType.WATERMARK)) {
+        currentWatermark = ((WatermarkEvent<T>) event).getWatermark();
+      }
+      StepTransformResult.Builder result =
+          StepTransformResult.withHold(application, currentWatermark);
+      if (event.getType().equals(EventType.ELEMENT)) {
+        UncommittedBundle<T> bundle = context.createRootBundle(application.getOutput());
+        for (TimestampedValue<T> elem : ((ElementEvent<T>) event).getElements()) {
+          bundle.add(WindowedValue.timestampedValueInGlobalWindow(elem.getValue(),
+              elem.getTimestamp()));
+        }
+        result.addOutput(bundle);
+      }
+      if (event.getType().equals(EventType.PROCESSING_TIME)) {
+        ((TestClock) context.getClock())
+            .advance(((ProcessingTimeEvent<T>) event).getProcessingTimeAdvance());
+      }
+      index++;
+      checkState(
+          !evaluators.replace(application, Optional.<Evaluator<?>>of(this)).isPresent(),
+          "The evaluator for a %s was changed while the source evaluator was executing. "
+              + "%s cannot be split or evaluated in parallel.",
+          TestStream.class.getSimpleName(),
+          TestStream.class.getSimpleName());
+      return result.build();
+    }
+  }
+
+  private static class TestClock implements Clock {
+    private final AtomicReference<Instant> currentTime =
+        new AtomicReference<>(BoundedWindow.TIMESTAMP_MIN_VALUE);
+
+    public void advance(Duration amount) {
+      Instant now = currentTime.get();
+      currentTime.compareAndSet(now, now.plus(amount));
+    }
+
+    @Override
+    public Instant now() {
+      return currentTime.get();
+    }
+  }
+
+  private static class TestClockSupplier implements Supplier<Clock> {
+    @Override
+    public Clock get() {
+      return new TestClock();
+    }
+  }
+
+  static class InProcessTestStreamFactory implements PTransformOverrideFactory {
+    @Override
+    public <InputT extends PInput, OutputT extends POutput> PTransform<InputT, OutputT> override(
+        PTransform<InputT, OutputT> transform) {
+      if (transform instanceof TestStream) {
+        return (PTransform<InputT, OutputT>)
+            new InProcessTestStream<OutputT>((TestStream<OutputT>) transform);
+      }
+      return transform;
+    }
+
+    private static class InProcessTestStream<T> extends PTransform<PBegin, PCollection<T>> {
+      private final TestStream<T> original;
+
+      private InProcessTestStream(TestStream transform) {
+        this.original = transform;
+      }
+
+      @Override
+      public PCollection<T> apply(PBegin input) {
+        PipelineRunner runner = input.getPipeline().getRunner();
+        checkState(runner instanceof InProcessPipelineRunner,
+            "%s can only be used when running with the %s",
+            getClass().getSimpleName(),
+            InProcessPipelineRunner.class.getSimpleName());
+        ((InProcessPipelineRunner) runner).setClockSupplier(new TestClockSupplier());
+        return PCollection.<T>createPrimitiveOutputInternal(
+            input.getPipeline(), WindowingStrategy.globalDefault(), IsBounded.UNBOUNDED)
+            .setCoder(original.getValueCoder());
+      }
+
+    }
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorRegistry.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformEvaluatorRegistry.java
@@ -17,15 +17,14 @@ package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import com.google.cloud.dataflow.sdk.io.Read;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
+import com.google.cloud.dataflow.sdk.testing.TestStream;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.transforms.Flatten.FlattenPCollectionList;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
 import com.google.common.collect.ImmutableMap;
-
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -47,6 +46,7 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
             .put(FlattenPCollectionList.class, new FlattenEvaluatorFactory())
             .put(ViewEvaluatorFactory.WriteView.class, new ViewEvaluatorFactory())
             .put(Window.Bound.class, new WindowEvaluatorFactory())
+            .put(TestStream.class, new TestStreamEvaluatorFactory())
             .build();
     return new TransformEvaluatorRegistry(primitives);
   }
@@ -70,5 +70,14 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
       throws Exception {
     TransformEvaluatorFactory factory = factories.get(application.getTransform().getClass());
     return factory.forApplication(application, inputBundle, evaluationContext);
+  }
+
+  /**
+   * A factory to create Transform Evaluator Registries.
+   */
+  public static class Factory {
+    public TransformEvaluatorRegistry create() {
+      return TransformEvaluatorRegistry.defaultRegistry();
+    }
   }
 }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/WriteWithShardingFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/WriteWithShardingFactory.java
@@ -58,7 +58,7 @@ class WriteWithShardingFactory implements PTransformOverrideFactory {
     return transform;
   }
 
-  private static class DynamicallyReshardedWrite <T> extends PTransform<PCollection<T>, PDone> {
+  private static class DynamicallyReshardedWrite<T> extends PTransform<PCollection<T>, PDone> {
     private final transient Write.Bound<T> original;
 
     private DynamicallyReshardedWrite(Write.Bound<T> original) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/DataflowAssert.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/DataflowAssert.java
@@ -193,6 +193,13 @@ public class DataflowAssert {
     IterableAssert<T> inCombinedNonLatePanes(BoundedWindow window);
 
     /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on panes in the {@link GlobalWindow} that were emitted before the {@link GlobalWindow}
+     * closed. These panes have {@link Timing#EARLY}.
+     */
+    IterableAssert<T> inEarlyGlobalWindowPanes();
+
+    /**
      * Asserts that the iterable in question contains the provided elements.
      *
      * @return the same {@link IterableAssert} builder for further assertions
@@ -438,6 +445,11 @@ public class DataflowAssert {
       return withPane(window, PaneExtractors.<T>nonLatePanes());
     }
 
+    @Override
+    public IterableAssert<T> inEarlyGlobalWindowPanes() {
+      return withPane(GlobalWindow.INSTANCE, PaneExtractors.<T>earlyPanes());
+    }
+
     private PCollectionContentsAssert<T> withPane(
         BoundedWindow window,
         SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> paneExtractor) {
@@ -627,6 +639,11 @@ public class DataflowAssert {
       return withPanes(window, PaneExtractors.<Iterable<T>>nonLatePanes());
     }
 
+    @Override
+    public IterableAssert<T> inEarlyGlobalWindowPanes() {
+      return withPanes(GlobalWindow.INSTANCE, PaneExtractors.<Iterable<T>>earlyPanes());
+    }
+
     private PCollectionSingletonIterableAssert<T> withPanes(
         BoundedWindow window,
         SimpleFunction<Iterable<WindowedValue<Iterable<T>>>, Iterable<Iterable<T>>> paneExtractor) {
@@ -726,6 +743,12 @@ public class DataflowAssert {
 
     @Override
     public IterableAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
+      throw new UnsupportedOperationException(
+          "IterableAssert of an PCollectionView does not support windowed assertions");
+    }
+
+    @Override
+    public IterableAssert<T> inEarlyGlobalWindowPanes() {
       throw new UnsupportedOperationException(
           "IterableAssert of an PCollectionView does not support windowed assertions");
     }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/DataflowAssert.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/DataflowAssert.java
@@ -725,32 +725,32 @@ public class DataflowAssert {
     @Override
     public IterableAssert<T> inWindow(BoundedWindow window) {
       throw new UnsupportedOperationException(
-          "IterableAssert of an PCollectionView does not support windowed assertions");
+          "IterableAssert of a PCollectionView does not support windowed assertions");
     }
 
     @Override
     public IterableAssert<T> inFinalPane(BoundedWindow window) {
       // TODO: Can maybe be supported?
       throw new UnsupportedOperationException(
-          "IterableAssert of an PCollectionView does not support windowed assertions");
+          "IterableAssert of a PCollectionView does not support windowed assertions");
     }
 
     @Override
     public IterableAssert<T> inOnTimePane(BoundedWindow window) {
       throw new UnsupportedOperationException(
-          "IterableAssert of an PCollectionView does not support windowed assertions");
+          "IterableAssert of a PCollectionView does not support windowed assertions");
     }
 
     @Override
     public IterableAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
       throw new UnsupportedOperationException(
-          "IterableAssert of an PCollectionView does not support windowed assertions");
+          "IterableAssert of a PCollectionView does not support windowed assertions");
     }
 
     @Override
     public IterableAssert<T> inEarlyGlobalWindowPanes() {
       throw new UnsupportedOperationException(
-          "IterableAssert of an PCollectionView does not support windowed assertions");
+          "IterableAssert of a PCollectionView does not support windowed assertions");
     }
 
     @Override

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/PaneExtractors.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/PaneExtractors.java
@@ -58,6 +58,10 @@ final class PaneExtractors {
     return new ExtractNonLatePanes<>();
   }
 
+  static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> earlyPanes() {
+    return new ExtractEarlyPanes<>();
+  }
+
   static <T> SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> allPanes() {
     return new ExtractAllPanes<>();
   }
@@ -130,6 +134,20 @@ final class PaneExtractors {
       List<T> outputs = new ArrayList<>();
       for (WindowedValue<T> value : input) {
         if (value.getPane().getTiming() != PaneInfo.Timing.LATE) {
+          outputs.add(value.getValue());
+        }
+      }
+      return outputs;
+    }
+  }
+
+  private static class ExtractEarlyPanes<T>
+      extends SimpleFunction<Iterable<WindowedValue<T>>, Iterable<T>> {
+    @Override
+    public Iterable<T> apply(Iterable<WindowedValue<T>> input) {
+      List<T> outputs = new ArrayList<>();
+      for (WindowedValue<T> value : input) {
+        if (value.getPane().getTiming() == PaneInfo.Timing.EARLY) {
           outputs.add(value.getValue());
         }
       }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/TestStream.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/TestStream.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.testing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.DurationCoder;
+import com.google.cloud.dataflow.sdk.coders.InstantCoder;
+import com.google.cloud.dataflow.sdk.coders.IterableCoder;
+import com.google.cloud.dataflow.sdk.coders.StandardCoder;
+import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.util.PropertyNames;
+import com.google.cloud.dataflow.sdk.util.VarInt;
+import com.google.cloud.dataflow.sdk.values.PBegin;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.TimestampedValue;
+import com.google.cloud.dataflow.sdk.values.TimestampedValue.TimestampedValueCoder;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.joda.time.ReadableDuration;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A testing input that generates an unbounded {@link PCollection} of elements, advancing the
+ * watermark and processing time as elements are emitted. After all of the specified elements are
+ * emitted, ceases to produce output.
+ *
+ * <p>Each call to a {@link TestStream.Builder} method will only be reflected in the state of the
+ * {@link Pipeline} after each method before it has completed and no more progress can be made by
+ * the {@link Pipeline}. A {@link PipelineRunner} must ensure that no more progress can be made in
+ * the {@link Pipeline} before advancing the state of the {@link TestStream}.
+ */
+public final class TestStream<T> extends PTransform<PBegin, PCollection<T>> {
+  private final List<Event<T>> events;
+  private final Coder<T> coder;
+
+  /**
+   * Create a new {@link TestStream.Builder} with no elements and watermark equal to {@link
+   * BoundedWindow#TIMESTAMP_MIN_VALUE}.
+   */
+  public static <T> Builder<T> create(Coder<T> coder) {
+    return new Builder<>(coder);
+  }
+
+  private TestStream(Coder<T> coder, List<Event<T>> events) {
+    this.coder = coder;
+    this.events = checkNotNull(events);
+  }
+
+  /**
+   * An incomplete {@link TestStream}. Elements added to this builder will be produced in sequence
+   * when the pipeline created by the {@link TestStream} is run.
+   */
+  public static class Builder<T> {
+    private final Coder<T> coder;
+    private final ImmutableList<Event<T>> events;
+    private final Instant currentWatermark;
+
+    private Builder(Coder<T> coder) {
+      this(coder, ImmutableList.<Event<T>>of(), BoundedWindow.TIMESTAMP_MIN_VALUE);
+    }
+
+    private Builder(Coder<T> coder, ImmutableList<Event<T>> events, Instant currentWatermark) {
+      this.coder = coder;
+      this.events = events;
+      this.currentWatermark = currentWatermark;
+    }
+
+    /**
+     * Adds the specified elements to the source with timestamp equal to the current watermark.
+     *
+     * @return A {@link TestStream.Builder} like this one that will add the provided elements
+     *         after all earlier events have completed.
+     */
+    @SafeVarargs
+    public final Builder<T> addElements(T first, T... rest) {
+      TimestampedValue<T> firstElement = TimestampedValue.of(first, currentWatermark);
+      @SuppressWarnings("unchecked")
+      TimestampedValue<T>[] remainingElements = new TimestampedValue[rest.length];
+      for (int i = 0; i < rest.length; i++) {
+        remainingElements[i] = TimestampedValue.of(rest[i], currentWatermark);
+      }
+      return addElements(firstElement, remainingElements);
+    }
+
+    /**
+     * Adds the specified elements to the source with the provided timestamps.
+     *
+     * @return A {@link TestStream.Builder} like this one that will add the provided elements
+     *         after all earlier events have completed.
+     */
+    @SafeVarargs
+    public final Builder<T> addElements(
+        TimestampedValue<T> first, TimestampedValue<T>... rest) {
+      checkArgument(
+          first.getTimestamp().isBefore(BoundedWindow.TIMESTAMP_MAX_VALUE),
+          "Elements must have timestamps before %s. Got: %s",
+          BoundedWindow.TIMESTAMP_MAX_VALUE,
+          first.getTimestamp());
+      for (TimestampedValue<T> element : rest) {
+        checkArgument(
+            element.getTimestamp().isBefore(BoundedWindow.TIMESTAMP_MAX_VALUE),
+            "Elements must have timestamps before %s. Got: %s",
+            BoundedWindow.TIMESTAMP_MAX_VALUE,
+            element.getTimestamp());
+      }
+      ImmutableList<Event<T>> newEvents =
+          ImmutableList.<Event<T>>builder()
+              .addAll(events)
+              .add(ElementEvent.add(first, rest))
+              .build();
+      return new Builder<T>(coder, newEvents, currentWatermark);
+    }
+
+    /**
+     * Advance the watermark of this source to the specified instant.
+     *
+     * <p>The watermark must advance monotonically and cannot advance to {@link
+     * BoundedWindow#TIMESTAMP_MAX_VALUE} or beyond.
+     *
+     * @return A {@link TestStream.Builder} like this one that will advance the watermark to the
+     *         specified point after all earlier events have completed.
+     */
+    public Builder<T> advanceWatermarkTo(Instant newWatermark) {
+      checkArgument(
+          newWatermark.isAfter(currentWatermark), "The watermark must monotonically advance");
+      checkArgument(
+          newWatermark.isBefore(BoundedWindow.TIMESTAMP_MAX_VALUE),
+          "The Watermark cannot progress beyond the maximum. Got: %s. Maximum: %s",
+          newWatermark,
+          BoundedWindow.TIMESTAMP_MAX_VALUE);
+      ImmutableList<Event<T>> newEvents = ImmutableList.<Event<T>>builder()
+          .addAll(events)
+          .add(WatermarkEvent.<T>advanceTo(newWatermark))
+          .build();
+      return new Builder<T>(coder, newEvents, newWatermark);
+    }
+
+    /**
+     * Advance the processing time by the specified amount.
+     *
+     * @return A {@link TestStream.Builder} like this one that will advance the processing time by
+     *         the specified amount after all earlier events have completed.
+     */
+    public Builder<T> advanceProcessingTime(Duration amount) {
+      checkArgument(
+          amount.getMillis() > 0,
+          "Must advance the processing time by a positive amount. Got: ",
+          amount);
+      ImmutableList<Event<T>> newEvents =
+          ImmutableList.<Event<T>>builder()
+              .addAll(events)
+              .add(ProcessingTimeEvent.<T>advanceBy(amount))
+              .build();
+      return new Builder<T>(coder, newEvents, currentWatermark);
+    }
+
+    /**
+     * Advance the watermark to infinity, completing this {@link TestStream}. Future calls to the
+     * same builder will not affect the returned {@link TestStream}.
+     */
+    public TestStream<T> advanceWatermarkToInfinity() {
+      ImmutableList<Event<T>> newEvents =
+          ImmutableList.<Event<T>>builder()
+              .addAll(events)
+              .add(WatermarkEvent.<T>advanceTo(BoundedWindow.TIMESTAMP_MAX_VALUE))
+              .build();
+      return new TestStream<>(coder, newEvents);
+    }
+  }
+
+  /**
+   * An event in a {@link TestStream}. A marker interface for all events that happen while
+   * evaluating a {@link TestStream}.
+   */
+  public interface Event<T> {
+    EventType getType();
+  }
+
+  /**
+   * The types of {@link Event} that are supported by {@link TestStream}.
+   */
+  public enum EventType {
+    ELEMENT,
+    WATERMARK,
+    PROCESSING_TIME
+  }
+
+  /** An {@link Event} that produces elements. */
+  @AutoValue
+  public abstract static class ElementEvent<T> implements Event<T> {
+    public abstract Iterable<TimestampedValue<T>> getElements();
+
+    @SafeVarargs
+    static <T> Event<T> add(TimestampedValue<T> element, TimestampedValue<T>... elements) {
+      return add(ImmutableList.<TimestampedValue<T>>builder().add(element).add(elements).build());
+    }
+
+    static <T> Event<T> add(Iterable<TimestampedValue<T>> elements) {
+      return new AutoValue_TestStream_ElementEvent<>(EventType.ELEMENT, elements);
+    }
+  }
+
+  /** An {@link Event} that advances the watermark. */
+  @AutoValue
+  public abstract static class WatermarkEvent<T> implements Event<T> {
+    public abstract Instant getWatermark();
+
+    static <T> Event<T> advanceTo(Instant newWatermark) {
+      return new AutoValue_TestStream_WatermarkEvent<>(EventType.WATERMARK, newWatermark);
+    }
+  }
+
+  /** An {@link Event} that advances the processing time clock. */
+  @AutoValue
+  public abstract static class ProcessingTimeEvent<T> implements Event<T> {
+    public abstract Duration getProcessingTimeAdvance();
+
+    static <T> Event<T> advanceBy(Duration amount) {
+      return new AutoValue_TestStream_ProcessingTimeEvent<>(EventType.PROCESSING_TIME, amount);
+    }
+  }
+
+  @Override
+  public PCollection<T> apply(PBegin input) {
+    throw new IllegalStateException(
+        String.format(
+            "Pipeline Runner %s does not support %s",
+            input.getPipeline().getRunner().getClass().getSimpleName(),
+            getClass().getSimpleName()));
+  }
+
+  public Coder<T> getValueCoder() {
+    return coder;
+  }
+
+  /**
+   * Returns a coder suitable for encoding {@link TestStream.Event}.
+   */
+  public Coder<Event<T>> getEventCoder() {
+    return EventCoder.of(coder);
+  }
+
+  /**
+   * Returns the sequence of {@link Event Events} in this {@link TestStream}.
+   *
+   * <p>For use by {@link PipelineRunner} authors.
+   */
+  public List<Event<T>> getEvents() {
+    return events;
+  }
+
+  /**
+   * A {@link Coder} that encodes and decodes {@link TestStream.Event Events}.
+   *
+   * @param <T> the type of elements in {@link ElementEvent ElementEvents} encoded and decoded by
+   *            this {@link EventCoder}
+   */
+  @VisibleForTesting
+  static final class EventCoder<T> extends StandardCoder<Event<T>> {
+    private static final Coder<ReadableDuration> DURATION_CODER = DurationCoder.of();
+    private static final Coder<Instant> INSTANT_CODER = InstantCoder.of();
+    private final Coder<T> valueCoder;
+    private final Coder<Iterable<TimestampedValue<T>>> elementCoder;
+
+    public static <T> EventCoder<T> of(Coder<T> valueCoder) {
+      return new EventCoder<>(valueCoder);
+    }
+
+    @JsonCreator
+    public static <T> EventCoder<T> of(
+        @JsonProperty(PropertyNames.COMPONENT_ENCODINGS) List<? extends Coder<?>> components) {
+      checkArgument(
+          components.size() == 1,
+          "Was expecting exactly one component coder, got %s",
+          components.size());
+      return new EventCoder<>((Coder<T>) components.get(0));
+    }
+
+    private EventCoder(Coder<T> valueCoder) {
+      this.valueCoder = valueCoder;
+      this.elementCoder = IterableCoder.of(TimestampedValueCoder.of(valueCoder));
+    }
+
+    @Override
+    public void encode(
+        Event<T> value, OutputStream outStream, Context context)
+        throws IOException {
+      VarInt.encode(value.getType().ordinal(), outStream);
+      switch (value.getType()) {
+        case ELEMENT:
+          Iterable<TimestampedValue<T>> elems = ((ElementEvent<T>) value).getElements();
+          elementCoder.encode(elems, outStream, context);
+          break;
+        case WATERMARK:
+          Instant ts = ((WatermarkEvent<T>) value).getWatermark();
+          INSTANT_CODER.encode(ts, outStream, context);
+          break;
+        case PROCESSING_TIME:
+          Duration processingAdvance = ((ProcessingTimeEvent<T>) value).getProcessingTimeAdvance();
+          DURATION_CODER.encode(processingAdvance, outStream, context);
+          break;
+        default:
+          throw new AssertionError("Unreachable: Unsupported Event Type " + value.getType());
+      }
+    }
+
+    @Override
+    public Event<T> decode(
+        InputStream inStream, Context context) throws IOException {
+      EventType eventType = EventType.values()[VarInt.decodeInt(inStream)];
+      switch (eventType) {
+        case ELEMENT:
+          Iterable<TimestampedValue<T>> elements = elementCoder.decode(inStream, context);
+          return ElementEvent.add(elements);
+        case WATERMARK:
+          return WatermarkEvent.advanceTo(INSTANT_CODER.decode(inStream, context));
+        case PROCESSING_TIME:
+          return ProcessingTimeEvent.advanceBy(
+              DURATION_CODER.decode(inStream, context).toDuration());
+        default:
+          throw new AssertionError("Unreachable: Unsupported Event Type " + eventType);
+      }
+    }
+
+    @Override
+    public List<? extends Coder<?>> getCoderArguments() {
+      return Collections.singletonList(valueCoder);
+    }
+
+    @Override
+    public void verifyDeterministic() throws NonDeterministicException {
+      elementCoder.verifyDeterministic();
+      DURATION_CODER.verifyDeterministic();
+      INSTANT_CODER.verifyDeterministic();
+    }
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/TestStream.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/testing/TestStream.java
@@ -97,7 +97,7 @@ public final class TestStream<T> extends PTransform<PBegin, PCollection<T>> {
     /**
      * Adds the specified elements to the source with timestamp equal to the current watermark.
      *
-     * @return A {@link TestStream.Builder} like this one that will add the provided elements
+     * @return A {@link TestStream.Builder} like this one that will emit the provided elements
      *         after all earlier events have completed.
      */
     @SafeVarargs
@@ -114,7 +114,7 @@ public final class TestStream<T> extends PTransform<PBegin, PCollection<T>> {
     /**
      * Adds the specified elements to the source with the provided timestamps.
      *
-     * @return A {@link TestStream.Builder} like this one that will add the provided elements
+     * @return A {@link TestStream.Builder} like this one that will emit the provided elements
      *         after all earlier events have completed.
      */
     @SafeVarargs

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContextTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContextTest.java
@@ -116,6 +116,7 @@ public class InProcessEvaluationContextTest {
     context =
         InProcessEvaluationContext.create(
             runner.getPipelineOptions(),
+            NanosOffsetClock.create(),
             InProcessBundleFactory.create(),
             rootTransforms,
             valueToConsumers,

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePoolTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePoolTest.java
@@ -1,0 +1,146 @@
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link LockedKeyedResourcePool}.
+ */
+@RunWith(JUnit4.class)
+public class LockedKeyedResourcePoolTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  private LockedKeyedResourcePool<String, Integer> cache =
+      LockedKeyedResourcePool.create();
+
+  @Test
+  public void acquireReleaseAcquireLastLoadedOrReleased() throws ExecutionException {
+    Optional<Integer> returned = cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 3;
+      }
+    });
+    assertThat(returned.get(), equalTo(3));
+
+    cache.release("foo", 4);
+    Optional<Integer> reacquired = cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 5;
+      }
+    });
+    assertThat(reacquired.get(), equalTo(4));
+  }
+
+  @Test
+  public void acquireReleaseReleaseThrows() throws ExecutionException {
+    Optional<Integer> returned = cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 3;
+      }
+    });
+    assertThat(returned.get(), equalTo(3));
+
+    cache.release("foo", 4);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("already a value present");
+    thrown.expectMessage("At most one");
+    cache.release("foo", 4);
+  }
+
+  @Test
+  public void releaseBeforeAcquireThrows() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("before a value was acquired");
+    cache.release("bar", 3);
+  }
+
+  @Test
+  public void multipleAcquireWithoutReleaseAbsent() throws ExecutionException {
+    Optional<Integer> returned = cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 3;
+      }
+    });
+    Optional<Integer> secondReturned = cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 3;
+      }
+    });
+    assertThat(secondReturned.isPresent(), is(false));
+  }
+
+  @Test
+  public void acquireMultipleKeysSucceeds() throws ExecutionException {
+    Optional<Integer> returned = cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 3;
+      }
+    });
+    Optional<Integer> secondReturned = cache.tryAcquire("bar", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return 4;
+      }
+    });
+
+    assertThat(returned.get(), equalTo(3));
+    assertThat(secondReturned.get(), equalTo(4));
+  }
+
+  @Test
+  public void acquireThrowsExceptionWrapped() throws ExecutionException {
+    final Exception cause = new Exception("checkedException");
+    thrown.expect(ExecutionException.class);
+    thrown.expectCause(equalTo(cause));
+    cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        throw cause;
+      }
+    });
+  }
+
+  @Test
+  public void acquireThrowsRuntimeExceptionWrapped() throws ExecutionException {
+    final RuntimeException cause = new RuntimeException("UncheckedException");
+    thrown.expect(UncheckedExecutionException.class);
+    thrown.expectCause(equalTo(cause));
+    cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        throw cause;
+      }
+    });
+  }
+
+  @Test
+  public void acquireThrowsErrorWrapped() throws ExecutionException {
+    final Error cause = new Error("Error");
+    thrown.expect(ExecutionError.class);
+    thrown.expectCause(equalTo(cause));
+    cache.tryAcquire("foo", new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        throw cause;
+      }
+    });
+  }
+}
+

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePoolTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/LockedKeyedResourcePoolTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.dataflow.sdk.runners.inprocess;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -7,13 +22,13 @@ import static org.junit.Assert.assertThat;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Tests for {@link LockedKeyedResourcePool}.

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TestStreamEvaluatorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TestStreamEvaluatorFactoryTest.java
@@ -1,0 +1,189 @@
+package com.google.cloud.dataflow.sdk.runners.inprocess;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
+import com.google.cloud.dataflow.sdk.testing.TestStream;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.util.WindowedValue;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.common.collect.Iterables;
+import org.hamcrest.Matchers;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TestStreamEvaluatorFactory}. */
+@RunWith(JUnit4.class)
+public class TestStreamEvaluatorFactoryTest {
+  private TestStreamEvaluatorFactory factory = new TestStreamEvaluatorFactory();
+  private BundleFactory bundleFactory = InProcessBundleFactory.create();
+
+  /** Demonstrates that returned evaluators produce elements in sequence. */
+  @Test
+  public void producesElementsInSequence() throws Exception {
+    TestPipeline p = TestPipeline.create();
+    PCollection<Integer> streamVals =
+        p.apply(
+            TestStream.create(VarIntCoder.of())
+                .addElements(1, 2, 3)
+                .addElements(4, 5, 6)
+                .advanceWatermarkToInfinity());
+
+    InProcessEvaluationContext context = mock(InProcessEvaluationContext.class);
+    when(context.createRootBundle(streamVals))
+        .thenReturn(
+            bundleFactory.createRootBundle(streamVals), bundleFactory.createRootBundle(streamVals));
+
+    TransformEvaluator<Object> firstEvaluator =
+        factory.forApplication(streamVals.getProducingTransformInternal(), null, context);
+    InProcessTransformResult firstResult = firstEvaluator.finishBundle();
+
+    TransformEvaluator<Object> secondEvaluator =
+        factory.forApplication(streamVals.getProducingTransformInternal(), null, context);
+    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
+
+    TransformEvaluator<Object> thirdEvaluator =
+        factory.forApplication(streamVals.getProducingTransformInternal(), null, context);
+    InProcessTransformResult thirdResult = thirdEvaluator.finishBundle();
+
+    assertThat(
+        Iterables.getOnlyElement(firstResult.getOutputBundles())
+            .commit(Instant.now())
+            .getElements(),
+        Matchers.<WindowedValue<?>>containsInAnyOrder(
+            WindowedValue.valueInGlobalWindow(1),
+            WindowedValue.valueInGlobalWindow(2),
+            WindowedValue.valueInGlobalWindow(3)));
+    assertThat(firstResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    assertThat(
+        Iterables.getOnlyElement(secondResult.getOutputBundles())
+            .commit(Instant.now())
+            .getElements(),
+        Matchers.<WindowedValue<?>>containsInAnyOrder(
+            WindowedValue.valueInGlobalWindow(4),
+            WindowedValue.valueInGlobalWindow(5),
+            WindowedValue.valueInGlobalWindow(6)));
+    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    assertThat(Iterables.isEmpty(thirdResult.getOutputBundles()), is(true));
+    assertThat(thirdResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
+  }
+
+  /** Demonstrates that at most one evaluator for an application is available at a time. */
+  @Test
+  public void onlyOneEvaluatorAtATime() throws Exception {
+    TestPipeline p = TestPipeline.create();
+    PCollection<Integer> streamVals =
+        p.apply(
+            TestStream.create(VarIntCoder.of()).addElements(4, 5, 6).advanceWatermarkToInfinity());
+
+    InProcessEvaluationContext context = mock(InProcessEvaluationContext.class);
+    TransformEvaluator<Object> firstEvaluator =
+        factory.forApplication(streamVals.getProducingTransformInternal(), null, context);
+
+    // create a second evaluator before the first is finished. The evaluator should not be available
+    TransformEvaluator<Object> secondEvaluator =
+        factory.forApplication(streamVals.getProducingTransformInternal(), null, context);
+    assertThat(secondEvaluator, is(nullValue()));
+  }
+
+  /**
+   * Demonstrates that multiple applications of the same {@link TestStream} produce separate
+   * evaluators.
+   */
+  @Test
+  public void multipleApplicationsMultipleEvaluators() throws Exception {
+    TestPipeline p = TestPipeline.create();
+    TestStream<Integer> stream =
+        TestStream.create(VarIntCoder.of()).addElements(2).advanceWatermarkToInfinity();
+    PCollection<Integer> firstVals = p.apply("Stream One", stream);
+    PCollection<Integer> secondVals = p.apply("Stream A", stream);
+
+    InProcessEvaluationContext context = mock(InProcessEvaluationContext.class);
+    when(context.createRootBundle(firstVals)).thenReturn(bundleFactory.createRootBundle(firstVals));
+    when(context.createRootBundle(secondVals))
+        .thenReturn(bundleFactory.createRootBundle(secondVals));
+
+    TransformEvaluator<Object> firstEvaluator =
+        factory.forApplication(firstVals.getProducingTransformInternal(), null, context);
+    // The two evaluators can exist independently
+    TransformEvaluator<Object> secondEvaluator =
+        factory.forApplication(secondVals.getProducingTransformInternal(), null, context);
+
+    InProcessTransformResult firstResult = firstEvaluator.finishBundle();
+    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
+
+    assertThat(
+        Iterables.getOnlyElement(firstResult.getOutputBundles())
+            .commit(Instant.now())
+            .getElements(),
+        Matchers.<WindowedValue<?>>containsInAnyOrder(WindowedValue.valueInGlobalWindow(2)));
+    assertThat(firstResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    // They both produce equal results, and don't interfere with each other
+    assertThat(
+        Iterables.getOnlyElement(secondResult.getOutputBundles())
+            .commit(Instant.now())
+            .getElements(),
+        Matchers.<WindowedValue<?>>containsInAnyOrder(WindowedValue.valueInGlobalWindow(2)));
+    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+  }
+
+  /**
+   * Demonstrates that multiple applications of different {@link TestStream} produce independent
+   * evaluators.
+   */
+  @Test
+  public void multipleStreamsMultipleEvaluators() throws Exception {
+    TestPipeline p = TestPipeline.create();
+    PCollection<Integer> firstVals =
+        p.apply(
+            "Stream One",
+            TestStream.create(VarIntCoder.of()).addElements(2).advanceWatermarkToInfinity());
+    PCollection<String> secondVals =
+        p.apply(
+            "Stream A",
+            TestStream.create(StringUtf8Coder.of())
+                .addElements("Two")
+                .advanceWatermarkToInfinity());
+
+    InProcessEvaluationContext context = mock(InProcessEvaluationContext.class);
+    when(context.createRootBundle(firstVals)).thenReturn(bundleFactory.createRootBundle(firstVals));
+    when(context.createRootBundle(secondVals))
+        .thenReturn(bundleFactory.createRootBundle(secondVals));
+
+    TransformEvaluator<Object> firstEvaluator =
+        factory.forApplication(firstVals.getProducingTransformInternal(), null, context);
+    // The two evaluators can exist independently
+    TransformEvaluator<Object> secondEvaluator =
+        factory.forApplication(secondVals.getProducingTransformInternal(), null, context);
+
+    InProcessTransformResult firstResult = firstEvaluator.finishBundle();
+    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
+
+    assertThat(
+        Iterables.getOnlyElement(firstResult.getOutputBundles())
+            .commit(Instant.now())
+            .getElements(),
+        Matchers.<WindowedValue<?>>containsInAnyOrder(WindowedValue.valueInGlobalWindow(2)));
+    assertThat(firstResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    assertThat(
+        Iterables.getOnlyElement(secondResult.getOutputBundles())
+            .commit(Instant.now())
+            .getElements(),
+        Matchers.<WindowedValue<?>>containsInAnyOrder(WindowedValue.valueInGlobalWindow("Two")));
+    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+  }
+}
+

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/TestStreamTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/TestStreamTest.java
@@ -50,7 +50,6 @@ import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
 import com.google.cloud.dataflow.sdk.transforms.windowing.Window.ClosingBehavior;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.TimestampedValue;
-import java.io.Serializable;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Rule;
@@ -58,10 +57,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import java.io.Serializable;
 
-/**
- * Tests for {@link TestStream}.
- */
+/** Tests for {@link TestStream}. */
 @RunWith(JUnit4.class)
 public class TestStreamTest implements Serializable {
   @Rule public transient ExpectedException thrown = ExpectedException.none();
@@ -69,89 +67,100 @@ public class TestStreamTest implements Serializable {
   @Test
   public void testLateDataAccumulating() {
     Instant instant = new Instant(0);
-    TestStream<Integer> source = TestStream.create(
-        VarIntCoder.of())
-        .addElements(TimestampedValue.of(1, instant),
-            TimestampedValue.of(2, instant),
-            TimestampedValue.of(3, instant))
-        .advanceWatermarkTo(instant.plus(Duration.standardMinutes(6)))
-        // These elements are late but within the allowed lateness
-        .addElements(TimestampedValue.of(4, instant), TimestampedValue.of(5, instant))
-        .advanceWatermarkTo(instant.plus(Duration.standardMinutes(20)))
-        // These elements are droppably late
-        .addElements(TimestampedValue.of(-1, instant),
-            TimestampedValue.of(-2, instant),
-            TimestampedValue.of(-3, instant))
-        .advanceWatermarkToInfinity();
+    TestStream<Integer> source =
+        TestStream.create(VarIntCoder.of())
+            .addElements(
+                TimestampedValue.of(1, instant),
+                TimestampedValue.of(2, instant),
+                TimestampedValue.of(3, instant))
+            .advanceWatermarkTo(instant.plus(Duration.standardMinutes(6)))
+            // These elements are late but within the allowed lateness
+            .addElements(TimestampedValue.of(4, instant), TimestampedValue.of(5, instant))
+            .advanceWatermarkTo(instant.plus(Duration.standardMinutes(20)))
+            // These elements are droppably late
+            .addElements(
+                TimestampedValue.of(-1, instant),
+                TimestampedValue.of(-2, instant),
+                TimestampedValue.of(-3, instant))
+            .advanceWatermarkToInfinity();
 
     Pipeline p = getPipeline();
-    PCollection<Integer> windowed = p
-        .apply(source)
-        .apply(Window.<Integer>into(FixedWindows.of(Duration.standardMinutes(5))).triggering(
-            AfterWatermark.pastEndOfWindow()
-                .withEarlyFirings(AfterProcessingTime.pastFirstElementInPane()
-                    .plusDelayOf(Duration.standardMinutes(2)))
-                .withLateFirings(AfterPane.elementCountAtLeast(1)))
-            .accumulatingFiredPanes()
-            .withAllowedLateness(Duration.standardMinutes(5), ClosingBehavior.FIRE_ALWAYS));
-    PCollection<Integer> triggered = windowed.apply(WithKeys.<Integer, Integer>of(1))
-        .apply(GroupByKey.<Integer, Integer>create())
-        .apply(Values.<Iterable<Integer>>create())
-        .apply(Flatten.<Integer>iterables());
+    PCollection<Integer> windowed =
+        p.apply(source)
+            .apply(
+                Window.<Integer>into(FixedWindows.of(Duration.standardMinutes(5)))
+                    .triggering(
+                        AfterWatermark.pastEndOfWindow()
+                            .withEarlyFirings(
+                                AfterProcessingTime.pastFirstElementInPane()
+                                    .plusDelayOf(Duration.standardMinutes(2)))
+                            .withLateFirings(AfterPane.elementCountAtLeast(1)))
+                    .accumulatingFiredPanes()
+                    .withAllowedLateness(Duration.standardMinutes(5), ClosingBehavior.FIRE_ALWAYS));
+    PCollection<Integer> triggered =
+        windowed
+            .apply(WithKeys.<Integer, Integer>of(1))
+            .apply(GroupByKey.<Integer, Integer>create())
+            .apply(Values.<Iterable<Integer>>create())
+            .apply(Flatten.<Integer>iterables());
     PCollection<Long> count = windowed.apply(Count.<Integer>globally().withoutDefaults());
     PCollection<Integer> sum = windowed.apply(Sum.integersGlobally().withoutDefaults());
 
     IntervalWindow window = new IntervalWindow(instant, instant.plus(Duration.standardMinutes(5L)));
-    DataflowAssert.that(triggered)
-        .inFinalPane(window)
-        .containsInAnyOrder(1, 2, 3, 4, 5);
-    DataflowAssert.that(triggered)
-        .inOnTimePane(window)
-        .containsInAnyOrder(1, 2, 3);
+    DataflowAssert.that(triggered).inFinalPane(window).containsInAnyOrder(1, 2, 3, 4, 5);
+    DataflowAssert.that(triggered).inOnTimePane(window).containsInAnyOrder(1, 2, 3);
     DataflowAssert.that(count)
         .inWindow(window)
-        .satisfies(new SerializableFunction<Iterable<Long>, Void>() {
-          @Override
-          public Void apply(Iterable<Long> input) {
-            for (Long count : input) {
-              assertThat(count, allOf(greaterThanOrEqualTo(3L), lessThanOrEqualTo(5L)));
-            }
-            return null;
-          }
-        });
+        .satisfies(
+            new SerializableFunction<Iterable<Long>, Void>() {
+              @Override
+              public Void apply(Iterable<Long> input) {
+                for (Long count : input) {
+                  assertThat(count, allOf(greaterThanOrEqualTo(3L), lessThanOrEqualTo(5L)));
+                }
+                return null;
+              }
+            });
     DataflowAssert.that(sum)
         .inWindow(window)
-        .satisfies(new SerializableFunction<Iterable<Integer>, Void>() {
-          @Override
-          public Void apply(Iterable<Integer> input) {
-            for (Integer sum : input) {
-              assertThat(sum, allOf(greaterThanOrEqualTo(6), lessThanOrEqualTo(15)));
-            }
-            return null;
-          }
-        });
+        .satisfies(
+            new SerializableFunction<Iterable<Integer>, Void>() {
+              @Override
+              public Void apply(Iterable<Integer> input) {
+                for (Integer sum : input) {
+                  assertThat(sum, allOf(greaterThanOrEqualTo(6), lessThanOrEqualTo(15)));
+                }
+                return null;
+              }
+            });
 
     p.run();
   }
 
   @Test
   public void testProcessingTimeTrigger() {
-    TestStream<Long> source = TestStream.create(
-        VarLongCoder.of())
-        .addElements(TimestampedValue.of(1L, new Instant(1000L)),
-            TimestampedValue.of(2L, new Instant(2000L)))
-        .advanceProcessingTime(Duration.standardMinutes(12))
-        .addElements(TimestampedValue.of(3L, new Instant(3000L)))
-        .advanceProcessingTime(Duration.standardMinutes(6))
-        .advanceWatermarkToInfinity();
+    TestStream<Long> source =
+        TestStream.create(VarLongCoder.of())
+            .addElements(
+                TimestampedValue.of(1L, new Instant(1000L)),
+                TimestampedValue.of(2L, new Instant(2000L)))
+            .advanceProcessingTime(Duration.standardMinutes(12))
+            .addElements(TimestampedValue.of(3L, new Instant(3000L)))
+            .advanceProcessingTime(Duration.standardMinutes(6))
+            .advanceWatermarkToInfinity();
 
     Pipeline p = getPipeline();
-    PCollection<Long> sum = p.apply(source)
-        .apply(Window.<Long>triggering(AfterWatermark.pastEndOfWindow()
-            .withEarlyFirings(AfterProcessingTime.pastFirstElementInPane()
-                .plusDelayOf(Duration.standardMinutes(5)))).accumulatingFiredPanes()
-            .withAllowedLateness(Duration.ZERO))
-        .apply(Sum.longsGlobally());
+    PCollection<Long> sum =
+        p.apply(source)
+            .apply(
+                Window.<Long>triggering(
+                        AfterWatermark.pastEndOfWindow()
+                            .withEarlyFirings(
+                                AfterProcessingTime.pastFirstElementInPane()
+                                    .plusDelayOf(Duration.standardMinutes(5))))
+                    .accumulatingFiredPanes()
+                    .withAllowedLateness(Duration.ZERO))
+            .apply(Sum.longsGlobally());
 
     DataflowAssert.that(sum).inEarlyGlobalWindowPanes().containsInAnyOrder(3L, 6L);
 
@@ -224,14 +233,17 @@ public class TestStreamTest implements Serializable {
     Pipeline p = getPipeline();
     FixedWindows windowFn = FixedWindows.of(Duration.millis(1000L));
     Duration allowedLateness = Duration.millis(5000L);
-    PCollection<String> values = p.apply(stream)
-        .apply(Window.<String>into(windowFn).triggering(DefaultTrigger.of())
-            .discardingFiredPanes()
-            .withAllowedLateness(allowedLateness))
-        .apply(WithKeys.<Integer, String>of(1))
-        .apply(GroupByKey.<Integer, String>create())
-        .apply(Values.<Iterable<String>>create())
-        .apply(Flatten.<String>iterables());
+    PCollection<String> values =
+        p.apply(stream)
+            .apply(
+                Window.<String>into(windowFn)
+                    .triggering(DefaultTrigger.of())
+                    .discardingFiredPanes()
+                    .withAllowedLateness(allowedLateness))
+            .apply(WithKeys.<Integer, String>of(1))
+            .apply(GroupByKey.<Integer, String>create())
+            .apply(Values.<Iterable<String>>create())
+            .apply(Flatten.<String>iterables());
 
     DataflowAssert.that(values).inWindow(windowFn.assignWindow(lateElementTimestamp)).empty();
     DataflowAssert.that(values)
@@ -244,19 +256,22 @@ public class TestStreamTest implements Serializable {
   @Test
   public void testElementsAtAlmostPositiveInfinity() {
     Instant endOfGlobalWindow = GlobalWindow.INSTANCE.maxTimestamp();
-    TestStream<String> stream = TestStream.create(StringUtf8Coder.of())
-        .addElements(TimestampedValue.of("foo", endOfGlobalWindow),
-            TimestampedValue.of("bar", endOfGlobalWindow))
-        .advanceWatermarkToInfinity();
+    TestStream<String> stream =
+        TestStream.create(StringUtf8Coder.of())
+            .addElements(
+                TimestampedValue.of("foo", endOfGlobalWindow),
+                TimestampedValue.of("bar", endOfGlobalWindow))
+            .advanceWatermarkToInfinity();
 
     Pipeline p = getPipeline();
     FixedWindows windows = FixedWindows.of(Duration.standardHours(6));
-    PCollection<String> windowedValues = p.apply(stream)
-        .apply(Window.<String>into(windows))
-        .apply(WithKeys.<Integer, String>of(1))
-        .apply(GroupByKey.<Integer, String>create())
-        .apply(Values.<Iterable<String>>create())
-        .apply(Flatten.<String>iterables());
+    PCollection<String> windowedValues =
+        p.apply(stream)
+            .apply(Window.<String>into(windows))
+            .apply(WithKeys.<Integer, String>of(1))
+            .apply(GroupByKey.<Integer, String>create())
+            .apply(Values.<Iterable<String>>create())
+            .apply(Flatten.<String>iterables());
 
     DataflowAssert.that(windowedValues)
         .inWindow(windows.assignWindow(GlobalWindow.INSTANCE.maxTimestamp()))
@@ -268,22 +283,26 @@ public class TestStreamTest implements Serializable {
   public void testMultipleStreams() {
     Pipeline p = getPipeline();
 
-    TestStream<String> stream = TestStream.create(StringUtf8Coder.of())
-        .addElements("foo", "bar")
-        .advanceWatermarkToInfinity();
+    TestStream<String> stream =
+        TestStream.create(StringUtf8Coder.of())
+            .addElements("foo", "bar")
+            .advanceWatermarkToInfinity();
 
-    TestStream<Integer> other = TestStream.create(VarIntCoder.of()).addElements(1, 2, 3, 4).advanceWatermarkToInfinity();
+    TestStream<Integer> other =
+        TestStream.create(VarIntCoder.of()).addElements(1, 2, 3, 4).advanceWatermarkToInfinity();
 
     PCollection<String> createStrings =
         p.apply("CreateStrings", stream)
-            .apply("WindowStrings",
+            .apply(
+                "WindowStrings",
                 Window.<String>triggering(AfterPane.elementCountAtLeast(2))
                     .withAllowedLateness(Duration.ZERO)
                     .accumulatingFiredPanes());
     DataflowAssert.that(createStrings).containsInAnyOrder("foo", "bar");
     PCollection<Integer> createInts =
         p.apply("CreateInts", other)
-            .apply("WindowInts",
+            .apply(
+                "WindowInts",
                 Window.<Integer>triggering(AfterPane.elementCountAtLeast(4))
                     .withAllowedLateness(Duration.ZERO)
                     .accumulatingFiredPanes());
@@ -304,8 +323,7 @@ public class TestStreamTest implements Serializable {
   @Test
   public void testAdvanceWatermarkNonMonotonicThrows() {
     Builder<Integer> stream =
-        TestStream.create(VarIntCoder.of())
-            .advanceWatermarkTo(new Instant(-1L));
+        TestStream.create(VarIntCoder.of()).advanceWatermarkTo(new Instant(-1L));
     thrown.expect(IllegalArgumentException.class);
     stream.advanceWatermarkTo(new Instant(-100L));
   }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/TestStreamTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/TestStreamTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.testing;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.coders.VarIntCoder;
+import com.google.cloud.dataflow.sdk.coders.VarLongCoder;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
+import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner;
+import com.google.cloud.dataflow.sdk.testing.TestStream.Builder;
+import com.google.cloud.dataflow.sdk.transforms.Count;
+import com.google.cloud.dataflow.sdk.transforms.Flatten;
+import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.cloud.dataflow.sdk.transforms.Sum;
+import com.google.cloud.dataflow.sdk.transforms.Values;
+import com.google.cloud.dataflow.sdk.transforms.WithKeys;
+import com.google.cloud.dataflow.sdk.transforms.windowing.AfterPane;
+import com.google.cloud.dataflow.sdk.transforms.windowing.AfterProcessingTime;
+import com.google.cloud.dataflow.sdk.transforms.windowing.AfterWatermark;
+import com.google.cloud.dataflow.sdk.transforms.windowing.BoundedWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.DefaultTrigger;
+import com.google.cloud.dataflow.sdk.transforms.windowing.FixedWindows;
+import com.google.cloud.dataflow.sdk.transforms.windowing.GlobalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.IntervalWindow;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Never;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window;
+import com.google.cloud.dataflow.sdk.transforms.windowing.Window.ClosingBehavior;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.TimestampedValue;
+import java.io.Serializable;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TestStream}.
+ */
+@RunWith(JUnit4.class)
+public class TestStreamTest implements Serializable {
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testLateDataAccumulating() {
+    Instant instant = new Instant(0);
+    TestStream<Integer> source = TestStream.create(
+        VarIntCoder.of())
+        .addElements(TimestampedValue.of(1, instant),
+            TimestampedValue.of(2, instant),
+            TimestampedValue.of(3, instant))
+        .advanceWatermarkTo(instant.plus(Duration.standardMinutes(6)))
+        // These elements are late but within the allowed lateness
+        .addElements(TimestampedValue.of(4, instant), TimestampedValue.of(5, instant))
+        .advanceWatermarkTo(instant.plus(Duration.standardMinutes(20)))
+        // These elements are droppably late
+        .addElements(TimestampedValue.of(-1, instant),
+            TimestampedValue.of(-2, instant),
+            TimestampedValue.of(-3, instant))
+        .advanceWatermarkToInfinity();
+
+    Pipeline p = getPipeline();
+    PCollection<Integer> windowed = p
+        .apply(source)
+        .apply(Window.<Integer>into(FixedWindows.of(Duration.standardMinutes(5))).triggering(
+            AfterWatermark.pastEndOfWindow()
+                .withEarlyFirings(AfterProcessingTime.pastFirstElementInPane()
+                    .plusDelayOf(Duration.standardMinutes(2)))
+                .withLateFirings(AfterPane.elementCountAtLeast(1)))
+            .accumulatingFiredPanes()
+            .withAllowedLateness(Duration.standardMinutes(5), ClosingBehavior.FIRE_ALWAYS));
+    PCollection<Integer> triggered = windowed.apply(WithKeys.<Integer, Integer>of(1))
+        .apply(GroupByKey.<Integer, Integer>create())
+        .apply(Values.<Iterable<Integer>>create())
+        .apply(Flatten.<Integer>iterables());
+    PCollection<Long> count = windowed.apply(Count.<Integer>globally().withoutDefaults());
+    PCollection<Integer> sum = windowed.apply(Sum.integersGlobally().withoutDefaults());
+
+    IntervalWindow window = new IntervalWindow(instant, instant.plus(Duration.standardMinutes(5L)));
+    DataflowAssert.that(triggered)
+        .inFinalPane(window)
+        .containsInAnyOrder(1, 2, 3, 4, 5);
+    DataflowAssert.that(triggered)
+        .inOnTimePane(window)
+        .containsInAnyOrder(1, 2, 3);
+    DataflowAssert.that(count)
+        .inWindow(window)
+        .satisfies(new SerializableFunction<Iterable<Long>, Void>() {
+          @Override
+          public Void apply(Iterable<Long> input) {
+            for (Long count : input) {
+              assertThat(count, allOf(greaterThanOrEqualTo(3L), lessThanOrEqualTo(5L)));
+            }
+            return null;
+          }
+        });
+    DataflowAssert.that(sum)
+        .inWindow(window)
+        .satisfies(new SerializableFunction<Iterable<Integer>, Void>() {
+          @Override
+          public Void apply(Iterable<Integer> input) {
+            for (Integer sum : input) {
+              assertThat(sum, allOf(greaterThanOrEqualTo(6), lessThanOrEqualTo(15)));
+            }
+            return null;
+          }
+        });
+
+    p.run();
+  }
+
+  @Test
+  public void testProcessingTimeTrigger() {
+    TestStream<Long> source = TestStream.create(
+        VarLongCoder.of())
+        .addElements(TimestampedValue.of(1L, new Instant(1000L)),
+            TimestampedValue.of(2L, new Instant(2000L)))
+        .advanceProcessingTime(Duration.standardMinutes(12))
+        .addElements(TimestampedValue.of(3L, new Instant(3000L)))
+        .advanceProcessingTime(Duration.standardMinutes(6))
+        .advanceWatermarkToInfinity();
+
+    Pipeline p = getPipeline();
+    PCollection<Long> sum = p.apply(source)
+        .apply(Window.<Long>triggering(AfterWatermark.pastEndOfWindow()
+            .withEarlyFirings(AfterProcessingTime.pastFirstElementInPane()
+                .plusDelayOf(Duration.standardMinutes(5)))).accumulatingFiredPanes()
+            .withAllowedLateness(Duration.ZERO))
+        .apply(Sum.longsGlobally());
+
+    DataflowAssert.that(sum).inEarlyGlobalWindowPanes().containsInAnyOrder(3L, 6L);
+
+    p.run();
+  }
+
+  /**
+   * A test that demonstrates that a Trigger in discarding mode fires multiple times, and elements
+   * that have been produced in a pane are not produced in future panes.
+   */
+  @Test
+  public void testDiscardingMode() {
+    TestStream<String> stream =
+        TestStream.create(StringUtf8Coder.of())
+            .advanceWatermarkTo(new Instant(0))
+            .addElements(
+                TimestampedValue.of("firstPane", new Instant(100)),
+                TimestampedValue.of("alsoFirstPane", new Instant(200)))
+            .addElements(TimestampedValue.of("onTimePane", new Instant(500)))
+            .advanceWatermarkTo(new Instant(1001L))
+            .addElements(
+                TimestampedValue.of("finalLatePane", new Instant(750)),
+                TimestampedValue.of("alsoFinalLatePane", new Instant(250)))
+            .advanceWatermarkToInfinity();
+
+    Pipeline p = getPipeline();
+    FixedWindows windowFn = FixedWindows.of(Duration.millis(1000L));
+    Duration allowedLateness = Duration.millis(5000L);
+    PCollection<String> values =
+        p.apply(stream)
+            .apply(
+                Window.<String>into(windowFn)
+                    .triggering(
+                        AfterWatermark.pastEndOfWindow()
+                            .withEarlyFirings(AfterPane.elementCountAtLeast(2))
+                            .withLateFirings(Never.ever()))
+                    .discardingFiredPanes()
+                    .withAllowedLateness(allowedLateness))
+            .apply(WithKeys.<Integer, String>of(1))
+            .apply(GroupByKey.<Integer, String>create())
+            .apply(Values.<Iterable<String>>create())
+            .apply(Flatten.<String>iterables());
+
+    IntervalWindow window = windowFn.assignWindow(new Instant(100));
+    DataflowAssert.that(values)
+        .inWindow(window)
+        .containsInAnyOrder(
+            "firstPane", "alsoFirstPane", "onTimePane", "finalLatePane", "alsoFinalLatePane");
+    DataflowAssert.that(values)
+        .inCombinedNonLatePanes(window)
+        .containsInAnyOrder("firstPane", "alsoFirstPane", "onTimePane");
+    DataflowAssert.that(values).inOnTimePane(window).containsInAnyOrder("onTimePane");
+    DataflowAssert.that(values)
+        .inFinalPane(window)
+        .containsInAnyOrder("finalLatePane", "alsoFinalLatePane");
+
+    p.run();
+  }
+
+  @Test
+  public void testFirstElementLate() {
+    Instant lateElementTimestamp = new Instant(-1_000_000);
+    TestStream<String> stream =
+        TestStream.create(StringUtf8Coder.of())
+            .advanceWatermarkTo(new Instant(-1))
+            .addElements(TimestampedValue.of("late", lateElementTimestamp))
+            .addElements(TimestampedValue.of("onTime", new Instant(100)))
+            .advanceWatermarkToInfinity();
+
+    Pipeline p = getPipeline();
+    FixedWindows windowFn = FixedWindows.of(Duration.millis(1000L));
+    Duration allowedLateness = Duration.millis(5000L);
+    PCollection<String> values = p.apply(stream)
+        .apply(Window.<String>into(windowFn).triggering(DefaultTrigger.of())
+            .discardingFiredPanes()
+            .withAllowedLateness(allowedLateness))
+        .apply(WithKeys.<Integer, String>of(1))
+        .apply(GroupByKey.<Integer, String>create())
+        .apply(Values.<Iterable<String>>create())
+        .apply(Flatten.<String>iterables());
+
+    DataflowAssert.that(values).inWindow(windowFn.assignWindow(lateElementTimestamp)).empty();
+    DataflowAssert.that(values)
+        .inWindow(windowFn.assignWindow(new Instant(100)))
+        .containsInAnyOrder("onTime");
+
+    p.run();
+  }
+
+  @Test
+  public void testElementsAtAlmostPositiveInfinity() {
+    Instant endOfGlobalWindow = GlobalWindow.INSTANCE.maxTimestamp();
+    TestStream<String> stream = TestStream.create(StringUtf8Coder.of())
+        .addElements(TimestampedValue.of("foo", endOfGlobalWindow),
+            TimestampedValue.of("bar", endOfGlobalWindow))
+        .advanceWatermarkToInfinity();
+
+    Pipeline p = getPipeline();
+    FixedWindows windows = FixedWindows.of(Duration.standardHours(6));
+    PCollection<String> windowedValues = p.apply(stream)
+        .apply(Window.<String>into(windows))
+        .apply(WithKeys.<Integer, String>of(1))
+        .apply(GroupByKey.<Integer, String>create())
+        .apply(Values.<Iterable<String>>create())
+        .apply(Flatten.<String>iterables());
+
+    DataflowAssert.that(windowedValues)
+        .inWindow(windows.assignWindow(GlobalWindow.INSTANCE.maxTimestamp()))
+        .containsInAnyOrder("foo", "bar");
+    p.run();
+  }
+
+  @Test
+  public void testMultipleStreams() {
+    Pipeline p = getPipeline();
+
+    TestStream<String> stream = TestStream.create(StringUtf8Coder.of())
+        .addElements("foo", "bar")
+        .advanceWatermarkToInfinity();
+
+    TestStream<Integer> other = TestStream.create(VarIntCoder.of()).addElements(1, 2, 3, 4).advanceWatermarkToInfinity();
+
+    PCollection<String> createStrings =
+        p.apply("CreateStrings", stream)
+            .apply("WindowStrings",
+                Window.<String>triggering(AfterPane.elementCountAtLeast(2))
+                    .withAllowedLateness(Duration.ZERO)
+                    .accumulatingFiredPanes());
+    DataflowAssert.that(createStrings).containsInAnyOrder("foo", "bar");
+    PCollection<Integer> createInts =
+        p.apply("CreateInts", other)
+            .apply("WindowInts",
+                Window.<Integer>triggering(AfterPane.elementCountAtLeast(4))
+                    .withAllowedLateness(Duration.ZERO)
+                    .accumulatingFiredPanes());
+    DataflowAssert.that(createInts).containsInAnyOrder(1, 2, 3, 4);
+
+    p.run();
+  }
+
+  @Test
+  public void testElementAtPositiveInfinityThrows() {
+    Builder<Integer> stream =
+        TestStream.create(VarIntCoder.of())
+            .addElements(TimestampedValue.of(-1, BoundedWindow.TIMESTAMP_MAX_VALUE.minus(1L)));
+    thrown.expect(IllegalArgumentException.class);
+    stream.addElements(TimestampedValue.of(1, BoundedWindow.TIMESTAMP_MAX_VALUE));
+  }
+
+  @Test
+  public void testAdvanceWatermarkNonMonotonicThrows() {
+    Builder<Integer> stream =
+        TestStream.create(VarIntCoder.of())
+            .advanceWatermarkTo(new Instant(-1L));
+    thrown.expect(IllegalArgumentException.class);
+    stream.advanceWatermarkTo(new Instant(-100L));
+  }
+
+  @Test
+  public void testAdvanceWatermarkEqualToPositiveInfinityThrows() {
+    Builder<Integer> stream =
+        TestStream.create(VarIntCoder.of())
+            .advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE.minus(1L));
+    thrown.expect(IllegalArgumentException.class);
+    stream.advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE);
+  }
+
+  private Pipeline getPipeline() {
+    PipelineOptions options = TestPipeline.testingPipelineOptions();
+    options.setRunner(InProcessPipelineRunner.class);
+    return TestPipeline.fromOptions(options);
+  }
+
+  @Test
+  public void testUnsupportedRunnerThrows() {
+    PipelineOptions opts = PipelineOptionsFactory.create();
+    opts.setRunner(DirectPipelineRunner.class);
+
+    Pipeline p = Pipeline.create(opts);
+
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("does not provide a required override");
+    thrown.expectMessage(TestStream.class.getSimpleName());
+    thrown.expectMessage(DirectPipelineRunner.class.getSimpleName());
+    p.apply(TestStream.create(VarIntCoder.of()).advanceWatermarkToInfinity());
+  }
+
+  @Test
+  public void testEncodeDecode() throws Exception {
+    TestStream.Event<Integer> elems =
+        TestStream.ElementEvent.add(
+            TimestampedValue.of(1, new Instant()),
+            TimestampedValue.of(-10, new Instant()),
+            TimestampedValue.of(Integer.MAX_VALUE, new Instant()));
+    TestStream.Event<Integer> wm = TestStream.WatermarkEvent.advanceTo(new Instant(100));
+    TestStream.Event<Integer> procTime =
+        TestStream.ProcessingTimeEvent.advanceBy(Duration.millis(90548));
+
+    TestStream.EventCoder<Integer> coder = TestStream.EventCoder.of(VarIntCoder.of());
+
+    CoderProperties.coderSerializable(coder);
+    CoderProperties.coderDecodeEncodeEqual(coder, elems);
+    CoderProperties.coderDecodeEncodeEqual(coder, wm);
+    CoderProperties.coderDecodeEncodeEqual(coder, procTime);
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/TestStreamTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/testing/TestStreamTest.java
@@ -333,7 +333,8 @@ public class TestStreamTest implements Serializable {
     Pipeline p = Pipeline.create(opts);
 
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("does not provide a required override");
+    thrown.expectMessage("DirectPipelineRunner");
+    thrown.expectMessage("does not support TestStream");
     thrown.expectMessage(TestStream.class.getSimpleName());
     thrown.expectMessage(DirectPipelineRunner.class.getSimpleName());
     p.apply(TestStream.create(VarIntCoder.of()).advanceWatermarkToInfinity());


### PR DESCRIPTION
This is a source suitable for use with tests that have interesting
triggering behavior. It is an Unbounded source that emits elements in
bundles, and advances the watermark and processing time appropriately.

TestStream is currently only supported in the InProcessPipelineRunner.

backports https://github.com/apache/incubator-beam/pull/817
backports https://github.com/apache/incubator-beam/pull/907