### PR TITLE
BigQueryTableRowIteratorTest: fix bug that resulted from merge conflict

### DIFF
--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIteratorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIteratorTest.java
@@ -246,6 +246,6 @@ public class BigQueryTableRowIteratorTest {
     // Job inserted to run the query, then polled once.
     verify(mockClient, times(1)).jobs();
     verify(mockJobs).insert(anyString(), any(Job.class));
-    verify(mockJobsInsert, times(3)).execute();
+    verify(mockJobsInsert, times(4)).execute();
   }
 }


### PR DESCRIPTION
Fixes this break: https://travis-ci.org/GoogleCloudPlatform/DataflowJavaSDK/builds/158022392

Since both PRs passed, I can only assume this is some weird conflict between Pei's PR and my PR.

#411 and #417