### PR TITLE
checkstyle: prohibit API client repackaged Guava

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -133,6 +133,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="illegalPkgs" value="com.google.api.client.repackaged, org.apache.beam"/>
     </module>
 
+    <!--
+        IllegalImport cannot blacklist classes, and c.g.api.client.util is used for some shaded
+        code and some useful code. So we need to fall back to Regexp.
+    -->
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>
+    </module>
+
     <module name="UnusedImports">
       <property name="severity" value="error"/>
       <property name="processJavadoc" value="true"/>

--- a/maven-archetypes/examples/src/main/resources/archetype-resources/src/main/java/DebuggingWordCount.java
+++ b/maven-archetypes/examples/src/main/resources/archetype-resources/src/main/java/DebuggingWordCount.java
@@ -151,7 +151,7 @@ public class DebuggingWordCount {
       }
     }
   }
-  
+
   /**
    * Options supported by {@link DebuggingWordCount}.
    *

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/CloudObject.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/CloudObject.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.dataflow.sdk.util;
 
-import static com.google.api.client.util.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Key;

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/OutputReference.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/OutputReference.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.dataflow.sdk.util;
 
-import static com.google.api.client.util.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Key;


### PR DESCRIPTION
Apparently the IllegalImport check only blocks packages,
so we had to move to Regexp to get individual classes.

This is a backport of apache/incubator-beam#872