### PR TITLE
BigQueryIO: enable users to control the SQL dialect

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -433,7 +433,8 @@ public class BigQueryIO {
        */
       public Bound named(String name) {
         return new Bound(
-            name, query, jsonTableRef, validate, flattenResults, useLegacySql, testBigQueryServices);
+            name, query, jsonTableRef, validate, flattenResults, useLegacySql,
+            testBigQueryServices);
       }
 
       /**

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -395,6 +395,7 @@ public class BigQueryIO {
       @Nullable final String query;
       final boolean validate;
       @Nullable final Boolean flattenResults;
+      @Nullable final Boolean useLegacySql;
       @Nullable BigQueryServices testBigQueryServices;
 
       private static final String QUERY_VALIDATION_FAILURE_ERROR =
@@ -408,17 +409,20 @@ public class BigQueryIO {
             null /* jsonTableRef */,
             true /* validate */,
             null /* flattenResults */,
+            null /* useLegacySql */,
             null /* testBigQueryServices */);
       }
 
       private Bound(
           String name, @Nullable String query, @Nullable String jsonTableRef, boolean validate,
-          @Nullable Boolean flattenResults, @Nullable BigQueryServices testBigQueryServices) {
+          @Nullable Boolean flattenResults, @Nullable Boolean useLegacySql,
+          @Nullable BigQueryServices testBigQueryServices) {
         super(name);
         this.jsonTableRef = jsonTableRef;
         this.query = query;
         this.validate = validate;
         this.flattenResults = flattenResults;
+        this.useLegacySql = useLegacySql;
         this.testBigQueryServices = testBigQueryServices;
       }
 
@@ -428,7 +432,8 @@ public class BigQueryIO {
        * <p>Does not modify this object.
        */
       public Bound named(String name) {
-        return new Bound(name, query, jsonTableRef, validate, flattenResults, testBigQueryServices);
+        return new Bound(
+            name, query, jsonTableRef, validate, flattenResults, useLegacySql, testBigQueryServices);
       }
 
       /**
@@ -448,7 +453,8 @@ public class BigQueryIO {
        */
       public Bound from(TableReference table) {
         return new Bound(
-            name, query, toJsonString(table), validate, flattenResults, testBigQueryServices);
+            name, query, toJsonString(table), validate, flattenResults, useLegacySql,
+            testBigQueryServices);
       }
 
       /**
@@ -460,17 +466,23 @@ public class BigQueryIO {
        * "flattenResults" in the <a href="https://cloud.google.com/bigquery/docs/reference/v2/jobs">
        * Jobs documentation</a> for more information.  To disable flattening, use
        * {@link BigQueryIO.Read.Bound#withoutResultFlattening}.
+       *
+       * <p>By default, the query will use BigQuery's legacy SQL dialect. To use the BigQuery
+       * Standard SQL dialect, use {@link BigQueryIO.Read.Bound#usingStandardSql}.
        */
       public Bound fromQuery(String query) {
         return new Bound(name, query, jsonTableRef, validate,
-            MoreObjects.firstNonNull(flattenResults, Boolean.TRUE), testBigQueryServices);
+            MoreObjects.firstNonNull(flattenResults, Boolean.TRUE),
+            MoreObjects.firstNonNull(useLegacySql, Boolean.TRUE),
+            testBigQueryServices);
       }
 
       /**
        * Disable table validation.
        */
       public Bound withoutValidation() {
-        return new Bound(name, query, jsonTableRef, false, flattenResults, testBigQueryServices);
+        return new Bound(
+            name, query, jsonTableRef, false, flattenResults, useLegacySql, testBigQueryServices);
       }
 
       /**
@@ -481,12 +493,25 @@ public class BigQueryIO {
        * from a table will cause an error during validation.
        */
       public Bound withoutResultFlattening() {
-        return new Bound(name, query, jsonTableRef, validate, false, testBigQueryServices);
+        return new Bound(
+            name, query, jsonTableRef, validate, false, useLegacySql, testBigQueryServices);
+      }
+
+      /**
+       * Enables BigQuery's Standard SQL dialect when reading from a query.
+       *
+       * <p>Only valid when a query is used ({@link #fromQuery}). Setting this option when reading
+       * from a table will cause an error during validation.
+       */
+      public Bound usingStandardSql() {
+        return new Bound(
+            name, query, jsonTableRef, validate, flattenResults, false, testBigQueryServices);
       }
 
       @VisibleForTesting
       Bound withTestServices(BigQueryServices testServices) {
-        return new Bound(name, query, jsonTableRef, validate, flattenResults, testServices);
+        return new Bound(
+            name, query, jsonTableRef, validate, flattenResults, useLegacySql, testServices);
       }
 
       @Override
@@ -523,6 +548,12 @@ public class BigQueryIO {
           } else if (query != null && flattenResults == null) {
             throw new IllegalStateException("Invalid BigQuery read operation. Specifies a"
                 + " query without a result flattening preference");
+          } else if (table != null && useLegacySql != null) {
+            throw new IllegalStateException("Invalid BigQuery read operation. Specifies a"
+                + " table with a SQL dialect preference, which is not configurable");
+          } else if (query != null && useLegacySql == null) {
+            throw new IllegalStateException("Invalid BigQuery read operation. Specifies a"
+                + " query without a SQL dialect preference");
           }
 
           // Check for source table/query presence for early failure notification.
@@ -534,16 +565,20 @@ public class BigQueryIO {
             verifyTablePresence(bqOptions, table);
           }
           if (query != null) {
-            dryRunQuery(bqOptions, query);
+            dryRunQuery(bqOptions, query, useLegacySql);
           }
         }
       }
 
-      private static void dryRunQuery(BigQueryOptions options, String query) {
+      private static void dryRunQuery(
+          BigQueryOptions options, String query, @Nullable Boolean useLegacySql) {
         Bigquery client = Transport.newBigQueryClient(options).build();
         QueryRequest request = new QueryRequest();
         request.setQuery(query);
         request.setDryRun(true);
+        if (useLegacySql != null) {
+          request.setUseLegacySql(useLegacySql);
+        }
 
         String queryValidationErrorMsg = String.format(QUERY_VALIDATION_FAILURE_ERROR, query);
         try {
@@ -586,7 +621,7 @@ public class BigQueryIO {
               .setTableId(queryTempTableId);
 
           source = BigQueryQuerySource.create(
-              jobIdToken, query, queryTempTableRef, flattenResults,
+              jobIdToken, query, queryTempTableRef, flattenResults, useLegacySql,
               extractDestinationDir, bqServices);
         } else {
           TableReference inputTable = getTableWithDefaultProject(bqOptions);
@@ -646,6 +681,8 @@ public class BigQueryIO {
               .withLabel("Query"))
             .addIfNotNull(DisplayData.item("flattenResults", flattenResults)
               .withLabel("Flatten Query Results"))
+            .addIfNotNull(DisplayData.item("useLegacySql", useLegacySql)
+              .withLabel("Use Legacy SQL Dialect"))
             .addIfNotDefault(DisplayData.item("validation", validate)
               .withLabel("Validation Enabled"),
                 true);
@@ -692,6 +729,15 @@ public class BigQueryIO {
        */
       public Boolean getFlattenResults() {
         return flattenResults;
+      }
+
+      /**
+       * Returns true (false) if the query will (will not) use BigQuery's legacy SQL mode, or null
+       * if not applicable.
+       */
+      @Nullable
+      public Boolean getUseLegacySql() {
+        return useLegacySql;
       }
 
       private BigQueryServices getBigQueryServices() {
@@ -834,15 +880,18 @@ public class BigQueryIO {
         String query,
         TableReference queryTempTableRef,
         Boolean flattenResults,
+        Boolean useLegacySql,
         String extractDestinationDir,
         BigQueryServices bqServices) {
       return new BigQueryQuerySource(
-          jobIdToken, query, queryTempTableRef, flattenResults, extractDestinationDir, bqServices);
+          jobIdToken, query, queryTempTableRef, flattenResults, useLegacySql, extractDestinationDir,
+          bqServices);
     }
 
     private final String query;
     private final String jsonQueryTempTable;
     private final Boolean flattenResults;
+    private final boolean useLegacySql;
     private transient AtomicReference<JobStatistics> dryRunJobStats;
 
     private BigQueryQuerySource(
@@ -850,6 +899,7 @@ public class BigQueryIO {
         String query,
         TableReference queryTempTableRef,
         Boolean flattenResults,
+        Boolean useLegacySql,
         String extractDestinationDir,
         BigQueryServices bqServices) {
       super(jobIdToken, extractDestinationDir, bqServices,
@@ -857,6 +907,7 @@ public class BigQueryIO {
       this.query = checkNotNull(query, "query");
       this.jsonQueryTempTable = toJsonString(queryTempTableRef);
       this.flattenResults = checkNotNull(flattenResults, "flattenResults");
+      this.useLegacySql = checkNotNull(useLegacySql, "useLegacySql");
       this.dryRunJobStats = new AtomicReference<>();
     }
 
@@ -870,7 +921,7 @@ public class BigQueryIO {
     public BoundedReader<TableRow> createReader(PipelineOptions options) throws IOException {
       BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
       return new BigQueryReader(this, bqServices.getReaderFromQuery(
-          bqOptions, query, executingProject, flattenResults));
+          bqOptions, query, executingProject, flattenResults, useLegacySql));
     }
 
     @Override
@@ -901,6 +952,7 @@ public class BigQueryIO {
           query,
           tableToExtract,
           flattenResults,
+          useLegacySql,
           bqServices.getJobService(bqOptions));
       return tableToExtract;
     }
@@ -939,6 +991,7 @@ public class BigQueryIO {
         String query,
         TableReference destinationTable,
         boolean flattenResults,
+        boolean useLegacySql,
         JobService jobService) throws IOException, InterruptedException {
       JobReference jobRef = new JobReference()
           .setProjectId(executingProject)
@@ -950,6 +1003,7 @@ public class BigQueryIO {
           .setCreateDisposition("CREATE_IF_NEEDED")
           .setDestinationTable(destinationTable)
           .setFlattenResults(flattenResults)
+          .setUseLegacySql(useLegacySql)
           .setPriority("BATCH")
           .setWriteDisposition("WRITE_EMPTY");
       jobService.startQueryJob(jobRef, queryConfig);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -482,7 +482,8 @@ public class BigQueryIO {
        */
       public Bound withoutValidation() {
         return new Bound(
-            name, query, jsonTableRef, false, flattenResults, useLegacySql, testBigQueryServices);
+            name, query, jsonTableRef, false /* validate */, flattenResults, useLegacySql,
+            testBigQueryServices);
       }
 
       /**
@@ -494,7 +495,8 @@ public class BigQueryIO {
        */
       public Bound withoutResultFlattening() {
         return new Bound(
-            name, query, jsonTableRef, validate, false, useLegacySql, testBigQueryServices);
+            name, query, jsonTableRef, validate, false /* flattenResults */, useLegacySql,
+            testBigQueryServices);
       }
 
       /**
@@ -505,7 +507,8 @@ public class BigQueryIO {
        */
       public Bound usingStandardSql() {
         return new Bound(
-            name, query, jsonTableRef, validate, flattenResults, false, testBigQueryServices);
+            name, query, jsonTableRef, validate, flattenResults, false /* useLegacySql */,
+            testBigQueryServices);
       }
 
       @VisibleForTesting

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
@@ -2184,6 +2184,8 @@ public class DataflowPipelineRunner extends PipelineRunner<DataflowPipelineJob> 
         context.addInput(PropertyNames.BIGQUERY_QUERY, originalTransform.getQuery());
         context.addInput(
             PropertyNames.BIGQUERY_FLATTEN_RESULTS, originalTransform.getFlattenResults());
+        context.addInput(
+            PropertyNames.BIGQUERY_USE_LEGACY_SQL, originalTransform.getUseLegacySql());
       } else {
         TableReference table = originalTransform.getTable();
         if (table.getProjectId() == null) {

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServices.java
@@ -58,7 +58,8 @@ public interface BigQueryServices extends Serializable {
    * Returns a real, mock, or fake {@link BigQueryJsonReader} to query tables.
    */
   public BigQueryJsonReader getReaderFromQuery(
-      BigQueryOptions bqOptions, String query, String projectId, @Nullable Boolean flatten);
+      BigQueryOptions bqOptions, String query, String projectId, @Nullable Boolean flatten,
+      @Nullable Boolean useLegacySql);
 
   /**
    * An interface for the Cloud BigQuery load service.

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServicesImpl.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryServicesImpl.java
@@ -83,8 +83,9 @@ public class BigQueryServicesImpl implements BigQueryServices {
 
   @Override
   public BigQueryJsonReader getReaderFromQuery(
-      BigQueryOptions bqOptions, String query, String projectId, @Nullable Boolean flatten) {
-    return BigQueryJsonReaderImpl.fromQuery(bqOptions, query, projectId, flatten);
+      BigQueryOptions bqOptions, String query, String projectId, @Nullable Boolean flatten,
+      @Nullable Boolean useLegacySql) {
+    return BigQueryJsonReaderImpl.fromQuery(bqOptions, query, projectId, flatten, useLegacySql);
   }
 
   @VisibleForTesting
@@ -521,10 +522,12 @@ public class BigQueryServicesImpl implements BigQueryServices {
         BigQueryOptions bqOptions,
         String query,
         String projectId,
-        @Nullable Boolean flattenResults) {
+        @Nullable Boolean flattenResults,
+        @Nullable Boolean useLegacySql) {
       return new BigQueryJsonReaderImpl(
           BigQueryTableRowIterator.fromQuery(
-              query, projectId, Transport.newBigQueryClient(bqOptions).build(), flattenResults));
+              query, projectId, Transport.newBigQueryClient(bqOptions).build(), flattenResults,
+              useLegacySql));
     }
 
     private static BigQueryJsonReader fromTable(

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIterator.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIterator.java
@@ -92,6 +92,8 @@ public class BigQueryTableRowIterator implements AutoCloseable {
   private final String query;
   // Whether to flatten query results.
   private final boolean flattenResults;
+  // Whether to use the BigQuery legacy SQL dialect..
+  private final boolean useLegacySql;
   // Temporary dataset used to store query results.
   private String temporaryDatasetId = null;
   // Temporary table used to store query results.
@@ -99,12 +101,13 @@ public class BigQueryTableRowIterator implements AutoCloseable {
 
   private BigQueryTableRowIterator(
       @Nullable TableReference ref, @Nullable String query, @Nullable String projectId,
-      Bigquery client, boolean flattenResults) {
+      Bigquery client, boolean flattenResults, boolean useLegacySql) {
     this.ref = ref;
     this.query = query;
     this.projectId = projectId;
     this.client = checkNotNull(client, "client");
     this.flattenResults = flattenResults;
+    this.useLegacySql = useLegacySql;
   }
 
   /**
@@ -113,7 +116,7 @@ public class BigQueryTableRowIterator implements AutoCloseable {
   public static BigQueryTableRowIterator fromTable(TableReference ref, Bigquery client) {
     checkNotNull(ref, "ref");
     checkNotNull(client, "client");
-    return new BigQueryTableRowIterator(ref, null, ref.getProjectId(), client, true);
+    return new BigQueryTableRowIterator(ref, null, ref.getProjectId(), client, true, true);
   }
 
   /**
@@ -121,12 +124,14 @@ public class BigQueryTableRowIterator implements AutoCloseable {
    * specified query in the specified project.
    */
   public static BigQueryTableRowIterator fromQuery(
-      String query, String projectId, Bigquery client, @Nullable Boolean flattenResults) {
+      String query, String projectId, Bigquery client, @Nullable Boolean flattenResults,
+      @Nullable Boolean useLegacySql) {
     checkNotNull(query, "query");
     checkNotNull(projectId, "projectId");
     checkNotNull(client, "client");
     return new BigQueryTableRowIterator(null, query, projectId, client,
-        MoreObjects.firstNonNull(flattenResults, Boolean.TRUE));
+        MoreObjects.firstNonNull(flattenResults, Boolean.TRUE),
+        MoreObjects.firstNonNull(useLegacySql, Boolean.TRUE));
   }
 
   /**
@@ -415,6 +420,8 @@ public class BigQueryTableRowIterator implements AutoCloseable {
     queryConfig.setQuery(query);
     queryConfig.setAllowLargeResults(true);
     queryConfig.setFlattenResults(flattenResults);
+    queryConfig.setUseLegacySql(useLegacySql);
+
 
     TableReference destinationTable = new TableReference();
     destinationTable.setProjectId(projectId);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/PropertyNames.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/PropertyNames.java
@@ -29,6 +29,7 @@ public class PropertyNames {
   public static final String BIGQUERY_TABLE = "table";
   public static final String BIGQUERY_QUERY = "bigquery_query";
   public static final String BIGQUERY_FLATTEN_RESULTS = "bigquery_flatten_results";
+  public static final String BIGQUERY_USE_LEGACY_SQL = "bigquery_use_legacy_sql";
   public static final String BIGQUERY_WRITE_DISPOSITION = "write_disposition";
   public static final String BIGQUERY_EXPORT_FORMAT = "bigquery_export_format";
   public static final String BIGQUERY_EXPORT_SCHEMA = "bigquery_export_schema";

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
@@ -711,7 +711,7 @@ public class BigQueryIOTest implements Serializable {
     assertThat(displayData, hasDisplayItem("table", tableSpec));
     assertThat(displayData, hasDisplayItem("query", "myQuery"));
     assertThat(displayData, hasDisplayItem("flattenResults", false));
-    assertThat(displayData, hasDisplayItem("usingStandardSql", true));
+    assertThat(displayData, hasDisplayItem("useLegacySql", false));
     assertThat(displayData, hasDisplayItem("validation", false));
   }
 

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/BigQueryIOTest.java
@@ -532,7 +532,7 @@ public class BigQueryIOTest implements Serializable {
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage(
-        "Invalid BigQuery read operation, either table reference or query has to be set");
+        "Invalid BigQueryIO.Read: one of table reference and query must be set");
     p.apply(BigQueryIO.Read.named("ReadMyTable"));
     p.run();
   }
@@ -547,8 +547,7 @@ public class BigQueryIOTest implements Serializable {
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage(
-        "Invalid BigQuery read operation. Specifies both a query and a table, only one of these"
-        + " should be provided");
+        "Invalid BigQueryIO.Read: table reference and query may not both be set");
     p.apply(
         BigQueryIO.Read.named("ReadMyTable")
             .from("foo.com:project:somedataset.sometable")
@@ -566,8 +565,8 @@ public class BigQueryIOTest implements Serializable {
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage(
-        "Invalid BigQuery read operation. Specifies a"
-              + " table with a result flattening preference, which is not configurable");
+        "Invalid BigQueryIO.Read: Specifies a table with a result flattening preference,"
+            + " which only applies to queries");
     p.apply(
         BigQueryIO.Read.named("ReadMyTable")
             .from("foo.com:project:somedataset.sometable")
@@ -585,8 +584,8 @@ public class BigQueryIOTest implements Serializable {
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage(
-        "Invalid BigQuery read operation. Specifies a"
-              + " table with a SQL dialect preference, which is not configurable");
+        "Invalid BigQueryIO.Read: Specifies a table with a SQL dialect preference,"
+            + " which only applies to queries");
     p.apply(
         BigQueryIO.Read.named("ReadMyTable")
             .from("foo.com:project:somedataset.sometable")

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIteratorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIteratorTest.java
@@ -179,7 +179,7 @@ public class BigQueryTableRowIteratorTest {
     // Run query and verify
     String query = "SELECT name, count from table";
     try (BigQueryTableRowIterator iterator =
-            BigQueryTableRowIterator.fromQuery(query, "project", mockClient, null)) {
+            BigQueryTableRowIterator.fromQuery(query, "project", mockClient, null, null)) {
       iterator.open();
       assertTrue(iterator.advance());
       TableRow row = iterator.getCurrent();
@@ -299,7 +299,7 @@ public class BigQueryTableRowIteratorTest {
 
     String query = "NOT A QUERY";
     try (BigQueryTableRowIterator iterator =
-            BigQueryTableRowIterator.fromQuery(query, "project", mockClient, null)) {
+            BigQueryTableRowIterator.fromQuery(query, "project", mockClient, null, null)) {
 
       try {
         iterator.open();

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIteratorTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/util/BigQueryTableRowIteratorTest.java
@@ -248,7 +248,7 @@ public class BigQueryTableRowIteratorTest {
     // Run query and verify
     String query = "SELECT \"Arthur\" as name, 42 as count";
     try (BigQueryTableRowIterator iterator =
-        BigQueryTableRowIterator.fromQuery(query, "project", mockClient, null)) {
+        BigQueryTableRowIterator.fromQuery(query, "project", mockClient, null, null)) {
       iterator.open();
       assertTrue(iterator.advance());
       TableRow row = iterator.getCurrent();


### PR DESCRIPTION
BigQuery 2.0 adds a new dialect of SQL, Standard SQL, and we need to
enable passing a specific option to BigQuery's APIs in order to support
it.