### PR TITLE
Deprecate TeardownPolicy for Dataflow service

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/DataflowPipelineWorkerPoolOptions.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/DataflowPipelineWorkerPoolOptions.java
@@ -189,7 +189,10 @@ public interface DataflowPipelineWorkerPoolOptions extends PipelineOptions {
 
   /**
    * The policy for tearing down the workers spun up by the service.
+   * @deprecated
+   * Dataflow Service will only support TEARDOWN_ALWAYS policy in the future.
    */
+  @Deprecated
   public enum TeardownPolicy {
     /**
      * All VMs created for a Dataflow job are deleted when the job finishes, regardless of whether


### PR DESCRIPTION
We are moving towards supporting only TEARDOWN_ALWAYS VM teardown policy.