### PR TITLE
[BEAM-639] BigtableIO: add support for users to scan table subranges

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/bigtable/BigtableIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/bigtable/BigtableIO.java
@@ -80,8 +80,9 @@ import javax.annotation.Nullable;
  *
  * <p>To configure a Cloud Bigtable source, you must supply a table id and a {@link BigtableOptions}
  * or builder configured with the project and other information necessary to identify the
- * Bigtable cluster. A {@link RowFilter} may also optionally be specified using
- * {@link BigtableIO.Read#withRowFilter}. For example:
+ * Bigtable cluster. By default, {@link BigtableIO.Read} will read all rows in the table. The row
+ * range to be read can optionally be restricted using {@link BigtableIO.Read#withKeyRange}, and
+ * a {@link RowFilter} can be specified using {@link BigtableIO.Read#withRowFilter}. For example:
  *
  * <pre>{@code
  * BigtableOptions.Builder optionsBuilder =
@@ -97,6 +98,14 @@ import javax.annotation.Nullable;
  *     BigtableIO.read()
  *         .withBigtableOptions(optionsBuilder)
  *         .withTableId("table"));
+ *
+ * // Scan a prefix of the table.
+ * ByteKeyRange keyRange = ...;
+ * p.apply("read",
+ *     BigtableIO.read()
+ *         .withBigtableOptions(optionsBuilder)
+ *         .withTableId("table")
+ *         .withKeyRange(keyRange));
  *
  * // Scan a subset of rows that match the specified row filter.
  * p.apply("filtered read",
@@ -158,7 +167,7 @@ public class BigtableIO {
    */
   @Experimental
   public static Read read() {
-    return new Read(null, "", null, null);
+    return new Read(null, "", ByteKeyRange.ALL_KEYS, null, null);
   }
 
   /**
@@ -221,7 +230,7 @@ public class BigtableIO {
                   .build());
       BigtableOptions optionsWithAgent = clonedBuilder.setUserAgent(getUserAgent()).build();
 
-      return new Read(optionsWithAgent, tableId, filter, bigtableService);
+      return new Read(optionsWithAgent, tableId, keyRange, filter, bigtableService);
     }
 
     /**
@@ -232,7 +241,17 @@ public class BigtableIO {
      */
     public Read withRowFilter(RowFilter filter) {
       checkNotNull(filter, "filter");
-      return new Read(options, tableId, filter, bigtableService);
+      return new Read(options, tableId, keyRange, filter, bigtableService);
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Read} that will read only rows in the specified range.
+     *
+     * <p>Does not modify this object.
+     */
+    public Read withKeyRange(ByteKeyRange keyRange) {
+      checkNotNull(keyRange, "keyRange");
+      return new Read(options, tableId, keyRange, filter, bigtableService);
     }
 
     /**
@@ -242,7 +261,7 @@ public class BigtableIO {
      */
     public Read withTableId(String tableId) {
       checkNotNull(tableId, "tableId");
-      return new Read(options, tableId, filter, bigtableService);
+      return new Read(options, tableId, keyRange, filter, bigtableService);
     }
 
     /**
@@ -250,6 +269,14 @@ public class BigtableIO {
      */
     public BigtableOptions getBigtableOptions() {
       return options;
+    }
+
+    /**
+     * Returns the range of keys that will be read from the table. By default, returns
+     * {@link ByteKeyRange#ALL_KEYS} to scan the entire table.
+     */
+    public ByteKeyRange getKeyRange() {
+      return keyRange;
     }
 
     /**
@@ -262,7 +289,7 @@ public class BigtableIO {
     @Override
     public PCollection<Row> apply(PBegin input) {
       BigtableSource source =
-          new BigtableSource(getBigtableService(), tableId, filter, ByteKeyRange.ALL_KEYS, null);
+          new BigtableSource(getBigtableService(), tableId, filter, keyRange, null);
       return input.getPipeline().apply(com.google.cloud.dataflow.sdk.io.Read.from(source));
     }
 
@@ -290,6 +317,9 @@ public class BigtableIO {
           .withLabel("Bigtable Options"));
       }
 
+      builder.addIfNotDefault(
+          DisplayData.item("keyRange", keyRange.toString()), ByteKeyRange.ALL_KEYS.toString());
+
       if (filter != null) {
         builder.add(DisplayData.item("rowFilter", filter.toString())
           .withLabel("Table Row Filter"));
@@ -301,6 +331,7 @@ public class BigtableIO {
       return MoreObjects.toStringHelper(Read.class)
           .add("options", options)
           .add("tableId", tableId)
+          .add("keyRange", keyRange)
           .add("filter", filter)
           .toString();
     }
@@ -313,16 +344,19 @@ public class BigtableIO {
      */
     @Nullable private final BigtableOptions options;
     private final String tableId;
+    private final ByteKeyRange keyRange;
     @Nullable private final RowFilter filter;
     @Nullable private final BigtableService bigtableService;
 
     private Read(
         @Nullable BigtableOptions options,
         String tableId,
+        ByteKeyRange keyRange,
         @Nullable RowFilter filter,
         @Nullable BigtableService bigtableService) {
       this.options = options;
       this.tableId = checkNotNull(tableId, "tableId");
+      this.keyRange = checkNotNull(keyRange, "keyRange");
       this.filter = filter;
       this.bigtableService = bigtableService;
     }
@@ -337,7 +371,7 @@ public class BigtableIO {
      */
     Read withBigtableService(BigtableService bigtableService) {
       checkNotNull(bigtableService, "bigtableService");
-      return new Read(options, tableId, filter, bigtableService);
+      return new Read(options, tableId, keyRange, filter, bigtableService);
     }
 
     /**
@@ -524,7 +558,7 @@ public class BigtableIO {
         String tableId,
         @Nullable RowFilter filter,
         ByteKeyRange range,
-        Long estimatedSizeBytes) {
+        @Nullable Long estimatedSizeBytes) {
       this.service = service;
       this.tableId = tableId;
       this.filter = filter;
@@ -544,7 +578,7 @@ public class BigtableIO {
 
     ////// Private state and internal implementation details //////
     private final BigtableService service;
-    @Nullable private final String tableId;
+    private final String tableId;
     @Nullable private final RowFilter filter;
     private final ByteKeyRange range;
     @Nullable private Long estimatedSizeBytes;


### PR DESCRIPTION
This is a backport of apache/incubator-beam#969