### PR TITLE
checkstyle.xml: blacklist imports of two shaded dependencies

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -130,7 +130,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
     </module>
 
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="com.google.api.client.repackaged, org.apache.beam"/>
+      <property name="illegalPkgs" value="avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged, org.apache.beam"/>
     </module>
 
     <!--


### PR DESCRIPTION
This is a backport of apache/incubator-beam#972