### PR TITLE
Remove RunnableOnService with tests with ExpectedException

### DIFF
--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.cloud.dataflow.sdk.Pipeline.PipelineExecutionException;
-import com.google.cloud.dataflow.sdk.testing.RunnableOnService;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Combine.CombineFn;
 import com.google.cloud.dataflow.sdk.transforms.Max.MaxIntegerFn;
@@ -31,7 +30,6 @@ import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -128,7 +126,6 @@ public class DoFnTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInStartBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFn<String, String>() {
       @Override
@@ -147,7 +144,6 @@ public class DoFnTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInProcessElementThrows() {
     TestPipeline p = createTestPipeline(new DoFn<String, String>() {
       @Override
@@ -163,7 +159,6 @@ public class DoFnTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInFinishBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFn<String, String>() {
       @Override

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnWithContextTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnWithContextTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.dataflow.sdk.Pipeline.PipelineExecutionException;
-import com.google.cloud.dataflow.sdk.testing.RunnableOnService;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Combine.CombineFn;
 import com.google.cloud.dataflow.sdk.transforms.Max.MaxIntegerFn;
@@ -35,7 +34,6 @@ import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -169,7 +167,6 @@ public class DoFnWithContextTest implements Serializable {
     assertThat(displayData.items(), empty());
   }
 
-  @Category(RunnableOnService.class)
   @Test
   public void testCreateAggregatorInStartBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFnWithContext<String, String>() {
@@ -189,7 +186,6 @@ public class DoFnWithContextTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInProcessElementThrows() {
     TestPipeline p = createTestPipeline(new DoFnWithContext<String, String>() {
       @ProcessElement
@@ -205,7 +201,6 @@ public class DoFnWithContextTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInFinishBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFnWithContext<String, String>() {
       @FinishBundle

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/WithTimestampsTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/WithTimestampsTest.java
@@ -83,7 +83,6 @@ public class WithTimestampsTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void withTimestampsBackwardsInTimeShouldThrow() {
     TestPipeline p = TestPipeline.create();
 


### PR DESCRIPTION
These tests aren't truly portable across runners, as excepitons thorwn
on failure may be different.