### PR TITLE
Add support for writing compressed files, and more...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ target/
 # The build process generates the dependency-reduced POM, but it shouldn't be
 # committed.
 dependency-reduced-pom.xml
+
+# Ignore Mac files.
+.DS_Store

--- a/examples/src/main/java8/com/google/cloud/dataflow/examples/ShakespeareWordCountToGzipFileSink.java
+++ b/examples/src/main/java8/com/google/cloud/dataflow/examples/ShakespeareWordCountToGzipFileSink.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.examples;
+
+import java.util.Arrays;
+
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink;
+import com.google.cloud.dataflow.sdk.io.TextIO;
+import com.google.cloud.dataflow.sdk.io.Write;
+import com.google.cloud.dataflow.sdk.io.WriterOutputGzipDecoratorFactory;
+import com.google.cloud.dataflow.sdk.options.DataflowPipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.runners.BlockingDataflowPipelineRunner;
+import com.google.cloud.dataflow.sdk.transforms.Count;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.Filter;
+import com.google.cloud.dataflow.sdk.transforms.FlatMapElements;
+import com.google.cloud.dataflow.sdk.transforms.MapElements;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.TypeDescriptor;
+import com.google.common.base.Preconditions;
+
+/**
+ * Example Google Dataflow pipeline showing how to use the {@link DecoratedFileSink} and
+ * {@link WriterOutputGzipDecoratorFactory} classes.
+ * <p>
+ * This does a word count against the files in {@code gs://dataflow-samples/shakespeare/*} resulting
+ * in output records of single {@value <word>,<count>} pairs, with the final output files in both
+ * plain text and Gzip compressed format.
+ *
+ * @author jeffkpayne
+ * @see DecoratedFileSink
+ * @see WriterOutputGzipDecoratorFactory
+ */
+public class ShakespeareWordCountToGzipFileSink {
+  public static void main(String[] args) {
+    // Set any necessary pipeline options.
+    final DataflowPipelineOptions options =
+        PipelineOptionsFactory.create().as(DataflowPipelineOptions.class);
+    options.setRunner(BlockingDataflowPipelineRunner.class);
+    options.setProject("<YOUR_GCP_PROJECT_ID>");
+    options.setStagingLocation("<YOUR_GCS_STAGING_LOCATION>");
+    // Wire together pipeline transforms.
+    final Pipeline p = Pipeline.create(options);
+    final PCollection<String> wc = p.apply(TextIO.Read.from("gs://dataflow-samples/shakespeare/*"))
+        .apply(FlatMapElements.via((String word) -> Arrays.asList(word.split("[^a-zA-Z']+")))
+            .withOutputType(new TypeDescriptor<String>() {}))
+        .apply(Filter.byPredicate((String word) -> !word.isEmpty()))
+        .apply(Count.<String>perElement())
+        .apply(MapElements
+            .via((KV<String, Long> wordCount) -> wordCount.getKey() + "," + wordCount.getValue())
+            .withOutputType(new TypeDescriptor<String>() {}));
+    wc.apply(TextIO.Write.named("WritePlainTextToGCS").to("<YOUR_GCS_PLAIN_TEXT_OUTPUT_LOCATION>"));
+    wc.apply("WriteGzipToGCS",
+        Write.to(new DecoratedFileSink<String>("<YOUR_GCS_PLAIN_TEXT_OUTPUT_LOCATION>", "txt",
+            TextIO.DEFAULT_TEXT_CODER, null, null,
+            WriterOutputGzipDecoratorFactory.getInstance())));
+    // Run pipeline.
+    p.run();
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/DecoratedFileSink.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/DecoratedFileSink.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+import javax.annotation.Nullable;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.Coder.Context;
+import com.google.cloud.dataflow.sdk.io.FileBasedSink;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.util.MimeTypes;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+/**
+ * The {@link WriterOutputDecoratorFactory} interface and {@link WriterOutputDecorator} abstract
+ * class are the hooks that allow for easily customizing how data gets written by
+ * {@link DecoratedFileSink} and related classes.
+ *
+ * @author jeffkpayne
+ *
+ */
+public class DecoratedFileSink<T> extends FileBasedSink<T> {
+  private final Coder<T> coder;
+  @Nullable
+  private final String header;
+  @Nullable
+  private final String footer;
+  private WriterOutputDecoratorFactory writerOutputDecoratorFactory;
+
+  public DecoratedFileSink(final String baseOutputFilename, final String extension,
+      final Coder<T> coder, @Nullable final String header, @Nullable final String footer,
+      final WriterOutputDecoratorFactory writerOutputDecoratorFactory) {
+    super(baseOutputFilename, Preconditions.checkNotNull(extension) + ".gz");
+    this.coder = coder;
+    this.header = header;
+    this.footer = footer;
+    this.writerOutputDecoratorFactory = writerOutputDecoratorFactory;
+  }
+
+  @Override
+  public DecoratedFileWriteOperation<T> createWriteOperation(PipelineOptions options) {
+    return new DecoratedFileWriteOperation<>(this, coder, header, footer,
+        writerOutputDecoratorFactory);
+  }
+
+  @VisibleForTesting
+  static class DecoratedFileWriter<T> extends FileBasedWriter<T> {
+    private static final byte[] NEWLINE = "\n".getBytes(StandardCharsets.UTF_8);
+    private final Coder<T> coder;
+    @Nullable
+    private final String header;
+    @Nullable
+    private final String footer;
+    private final WriterOutputDecoratorFactory writerOutputDecoratorFactory;
+    private WriterOutputDecorator writerOutputDecorator;
+
+    private DecoratedFileWriter(final DecoratedFileWriteOperation<T> writeOperation,
+        final Coder<T> coder, @Nullable final String header, @Nullable final String footer,
+        final WriterOutputDecoratorFactory writerOutputDecoratorFactory) {
+      super(writeOperation);
+      this.coder = coder;
+      this.header = header;
+      this.footer = footer;
+      this.writerOutputDecoratorFactory = writerOutputDecoratorFactory;
+      this.mimeType = writerOutputDecoratorFactory.getMimeType();
+    }
+
+    /**
+     * Writes {@code value} followed by a newline if {@code value} is not null.
+     */
+    private void writeIfNotNull(@Nullable String value) throws IOException {
+      if (value != null) {
+        synchronized (writerOutputDecorator) {
+          writerOutputDecorator.write(value.getBytes(StandardCharsets.UTF_8));
+          writerOutputDecorator.write(NEWLINE);
+        }
+      }
+    }
+
+    @Override
+    protected void prepareWrite(WritableByteChannel channel) throws Exception {
+      writerOutputDecorator =
+          writerOutputDecoratorFactory.create(Channels.newOutputStream(channel));
+    }
+
+    @Override
+    protected void writeHeader() throws Exception {
+      writeIfNotNull(header);
+    }
+
+    @Override
+    protected void writeFooter() throws Exception {
+      writeIfNotNull(footer);
+      writerOutputDecorator.finish();
+    }
+
+    @Override
+    public void write(T value) throws Exception {
+      synchronized (writerOutputDecorator) {
+        coder.encode(value, writerOutputDecorator, Context.OUTER);
+        writerOutputDecorator.write(NEWLINE);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static class DecoratedFileWriteOperation<T> extends FileBasedWriteOperation<T> {
+    private final Coder<T> coder;
+    @Nullable
+    private final String header;
+    @Nullable
+    private final String footer;
+    private final WriterOutputDecoratorFactory writerOutputDecoratorFactory;
+
+    /**
+     * @param sink
+     */
+    public DecoratedFileWriteOperation(final DecoratedFileSink<T> sink, final Coder<T> coder,
+        @Nullable final String header, @Nullable final String footer,
+        final WriterOutputDecoratorFactory writerOutputDecoratorFactory) {
+      super(sink);
+      this.coder = coder;
+      this.header = header;
+      this.footer = footer;
+      this.writerOutputDecoratorFactory = writerOutputDecoratorFactory;
+    }
+
+    /**
+     * @see FileBasedWriteOperation#createWriter(PipelineOptions)
+     */
+    @Override
+    public DecoratedFileWriter<T> createWriter(PipelineOptions options) throws Exception {
+      return new DecoratedFileWriter<>(this, coder, header, footer, writerOutputDecoratorFactory);
+    }
+  }
+
+  /**
+   * Implementations create instances of {@link WriterOutputDecorator} used by
+   * {@link DecoratedFileSink} and related classes to allow <em>decorating</em>, or otherwise
+   * transforming, the raw data that would normally be written directly to the {@link OutputStream}
+   * passed into {@link WriterOutputDecoratorFactory#create(OutputStream)}.
+   *
+   * @author jeffkpayne
+   *
+   */
+  public interface WriterOutputDecoratorFactory extends Serializable {
+    /**
+     * @param out the {@link OutputStream} to write the decorated, or otherwise transformed, data to
+     * @return the {@link WriterOutputDecorator} decorating, or otherwise transforming, the raw data
+     *         before writing it to <var>out</var>
+     * @throws IOException
+     */
+    public WriterOutputDecorator create(OutputStream out) throws IOException;
+
+    /**
+     * @return the MIME type that should be used for the files that will hold the output data
+     * @see MimeTypes
+     * @see <a href=
+     *      'http://www.iana.org/assignments/media-types/media-types.xhtml'>http://www.iana.org/assignments/media-types/media-types.xhtml</a>
+     */
+    public String getMimeType();
+  }
+
+  /**
+   * Subclasses of this should <em>decorate</em>, or otherwise transform, the raw data that would
+   * normally be written directly to the {@link OutputStream} passed into
+   * {@link WriterOutputDecoratorFactory#create(OutputStream)}. Implementations can accomplish this
+   * by creating an {@link OutputStream} and passing it into
+   * {@link WriterOutputDecorator#WriterOutputDecorator(OutputStream)}.
+   * <p>
+   * The {@link #finish()} hook is provided for any logic needed to <em>finish</em> writing to the
+   * underlying stream without closing it.
+   *
+   * @author jeffkpayne
+   * @see GZIPOutputStream#finish()
+   */
+  public static abstract class WriterOutputDecorator extends OutputStream {
+    protected final OutputStream out;
+
+    public WriterOutputDecorator(final OutputStream out) {
+      this.out = out;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      out.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      out.close();
+    }
+
+    /**
+     * Provided for any logic needed to <em>finish</em> writing to the {@link WritableByteChannel}
+     * without closing the underlying stream. This gets called after any <em>footer</em> data is
+     * written by the underlying {@link FileBasedWriter}.
+     * <p>
+     * Default implementation is a no-op.
+     *
+     * @throws IOException
+     */
+    public void finish() throws IOException {};
+  }
+}

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/WriterOutputGzipDecoratorFactory.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/WriterOutputGzipDecoratorFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.dataflow.sdk.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink.WriterOutputDecorator;
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink.WriterOutputDecoratorFactory;
+import com.google.cloud.dataflow.sdk.util.MimeTypes;
+
+/**
+ * Implementation of {@link WriterOutputDecoratorFactory} and {@link WriterOutputDecorator} that provide gzip support
+ * via {@link GZIPOutputStream}.
+ *
+ * @author jeffkpayne
+ *
+ */
+public class WriterOutputGzipDecoratorFactory implements WriterOutputDecoratorFactory {
+  private static final WriterOutputGzipDecoratorFactory INSTANCE =
+      new WriterOutputGzipDecoratorFactory();
+
+  public static WriterOutputGzipDecoratorFactory getInstance() {
+    return INSTANCE;
+  }
+
+  private WriterOutputGzipDecoratorFactory() {}
+
+  @Override
+  public WriterOutputDecorator create(final OutputStream out) throws IOException {
+    return new WriterOutputGzipDecorator(out);
+  }
+
+  @Override
+  public String getMimeType() {
+    return MimeTypes.BINARY;
+  }
+
+  private class WriterOutputGzipDecorator extends WriterOutputDecorator {
+    private final GZIPOutputStream gzip;
+
+    private WriterOutputGzipDecorator(final OutputStream out) throws IOException {
+      super(new GZIPOutputStream(out, true));
+      this.gzip = (GZIPOutputStream) super.out;
+    }
+
+    @Override
+    public void finish() throws IOException {
+      gzip.finish();
+    }
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/DecoratedFileSinkTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/DecoratedFileSinkTest.java
@@ -1,0 +1,120 @@
+package com.google.cloud.dataflow.sdk.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink.DecoratedFileWriter;
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink.WriterOutputDecorator;
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink.WriterOutputDecoratorFactory;
+import com.google.cloud.dataflow.sdk.io.FileBasedSink.FileResult;
+import com.google.cloud.dataflow.sdk.io.TextIO;
+import com.google.cloud.dataflow.sdk.util.MimeTypes;
+
+@RunWith(JUnit4.class)
+public class DecoratedFileSinkTest {
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private static final String TEMPORARY_FILENAME_SEPARATOR = "-temp-";
+  private String baseOutputFilename = "output";
+  private String baseTemporaryFilename = "temp";
+
+  private String appendToTempFolder(String filename) {
+    return Paths.get(tmpFolder.getRoot().getPath(), filename).toString();
+  }
+
+  private String getBaseOutputFilename() {
+    return appendToTempFolder(baseOutputFilename);
+  }
+
+  private String getBaseTempFilename() {
+    return appendToTempFolder(baseTemporaryFilename);
+  }
+
+  /**
+   * Assert that a file contains the lines provided, in the same order as expected.
+   */
+  private void assertFileContains(List<String> expected, String filename) throws Exception {
+    try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+      List<String> actual = new ArrayList<>();
+      for (;;) {
+        String line = reader.readLine();
+        if (line == null) {
+          break;
+        }
+        actual.add(line);
+      }
+      assertEquals(expected, actual);
+    }
+  }
+
+  /**
+   * {@link DecoratedFileWriter} writes to the {@link WriterOutputDecorator} provided by
+   * {@link WriterOutputDecoratorFactory}.
+   */
+  @Test
+  public void testDecoratedFileWriter() throws Exception {
+    final String testUid = "testId";
+    final String expectedFilename =
+        getBaseOutputFilename() + TEMPORARY_FILENAME_SEPARATOR + testUid;
+    final DecoratedFileWriter<String> writer =
+        new DecoratedFileSink<String>(getBaseOutputFilename(), "txt", TextIO.DEFAULT_TEXT_CODER,
+            "h", "f", new SimpleDecoratorFactory()).createWriteOperation(null).createWriter(null);
+
+    final List<String> expected = new ArrayList<>();
+    expected.add("hh");
+    expected.add("");
+    expected.add("aa");
+    expected.add("");
+    expected.add("bb");
+    expected.add("");
+    expected.add("ff");
+    expected.add("");
+
+    writer.open(testUid);
+    writer.write("a");
+    writer.write("b");
+    final FileResult result = writer.close();
+
+    assertEquals(expectedFilename, result.getFilename());
+    assertFileContains(expected, expectedFilename);
+  }
+
+  private static class SimpleDecoratorFactory implements WriterOutputDecoratorFactory {
+    @Override
+    public WriterOutputDecorator create(OutputStream out) throws IOException {
+      return new SimpleDecorator(out);
+    }
+
+    @Override
+    public String getMimeType() {
+      return MimeTypes.TEXT;
+    }
+
+    private static class SimpleDecorator extends WriterOutputDecorator {
+      public SimpleDecorator(final OutputStream out) {
+        // OutputStream just writes each byte twice.
+        super(new OutputStream() {
+          @Override
+          public void write(int b) throws IOException {
+            out.write(b);
+            out.write(b);
+          }
+        });
+      }
+    }
+  }
+}

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/WriterOutputGzipDecoratorFactoryTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/WriterOutputGzipDecoratorFactoryTest.java
@@ -1,0 +1,47 @@
+package com.google.cloud.dataflow.sdk.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.dataflow.sdk.io.DecoratedFileSink.WriterOutputDecorator;
+
+@RunWith(JUnit4.class)
+public class WriterOutputGzipDecoratorFactoryTest {
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void testCreateAndWrite() throws FileNotFoundException, IOException {
+    final WriterOutputGzipDecoratorFactory factory = WriterOutputGzipDecoratorFactory.getInstance();
+    final File file = tmpFolder.newFile("test.gz");
+    final OutputStream fos = new FileOutputStream(file);
+    final WriterOutputDecorator decorator = factory.create(fos);
+    decorator.write("abc\n".getBytes(StandardCharsets.UTF_8));
+    decorator.out.write("123\n".getBytes(StandardCharsets.UTF_8));
+    decorator.finish();
+    decorator.close();
+    // Read Gzipped data back in using standard API.
+    final BufferedReader br =
+        new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(file)),
+            StandardCharsets.UTF_8.name()));
+    assertEquals("First line should read 'abc'", "abc", br.readLine());
+    assertEquals("Second line should read '123'", "123", br.readLine());
+  }
+
+}


### PR DESCRIPTION
Looking for some feedback from the maintainers on this solution to #404.  I realize that the test coverage might be a little light for DataflowJavaSDK standards and have no problem expanding that if needed.

The DecoratedFileSink class provides a hook for decorating/transforming data output _at the WritableByteChannel/OutputStream level_ to enable things like Gzip compression during shard file writes.  I included a concrete implementation, WriterOutputGzipDecoratorFactory, of the hook interface, which enables Gzip output, and is currently in use by us at Bombora.  My thinking was that a hook at this level would enable any _file level_ transformation (as opposed to field or record level) that could be done via wrapping an OutputStream.
- ENH: Add customizable file-based output support through DecoratedFileSink and concrete Gzip file-based output support through WriterOutputGzipDecoratorFactory (solves #404)
- DOC: Add a little more documentation and an example pipeline (solves #404)
