### PR TITLE
Backport display data fixes

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BoundedReadFromUnboundedSource.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BoundedReadFromUnboundedSource.java
@@ -202,6 +202,12 @@ class BoundedReadFromUnboundedSource<T> extends PTransform<PInput, PCollection<T
       return new Reader(source.createReader(options, null));
     }
 
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      builder.add(DisplayData.item("source", source.getClass()));
+      builder.include(source);
+    }
+
     private class Reader extends BoundedReader<ValueWithRecordId<T>> {
       private long recordsRead = 0L;
       private Instant endTime = Instant.now().plus(maxReadTime);

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandler.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandler.java
@@ -331,7 +331,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
           builder.add(DisplayData.item(option.getKey(), type, value)
               .withNamespace(pipelineInterface));
         } else {
-          builder.add(DisplayData.item(option.getKey(), value.toString())
+          builder.add(DisplayData.item(option.getKey(), displayDataString(value))
               .withNamespace(pipelineInterface));
         }
       }
@@ -360,13 +360,32 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
             builder.add(DisplayData.item(jsonOption.getKey(), type, value)
                 .withNamespace(spec.getDefiningInterface()));
           } else {
-            builder.add(DisplayData.item(jsonOption.getKey(), value.toString())
+            builder.add(DisplayData.item(jsonOption.getKey(), displayDataString(value))
                 .withNamespace(spec.getDefiningInterface()));
           }
         }
       }
     }
   }
+
+  /**
+   * {@link Object#toString()} wrapper to extract display data values for various types.
+   */
+  private String displayDataString(Object value) {
+    checkNotNull(value, "value cannot be null");
+    if (!value.getClass().isArray()) {
+      return value.toString();
+    }
+    if (!value.getClass().getComponentType().isPrimitive()) {
+      return Arrays.deepToString((Object[]) value);
+    }
+
+    // At this point, we have some type of primitive array. Arrays.deepToString(..) requires an
+    // Object array, but will unwrap nested primitive arrays.
+    String wrapped = Arrays.deepToString(new Object[]{value});
+    return wrapped.substring(1, wrapped.length() - 1);
+  }
+
 
   /**
    * Marker interface used when the original {@link PipelineOptions} interface is not known at

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandler.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandler.java
@@ -386,7 +386,6 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
     return wrapped.substring(1, wrapped.length() - 1);
   }
 
-
   /**
    * Marker interface used when the original {@link PipelineOptions} interface is not known at
    * runtime. This can occur if {@link PipelineOptions} are deserialized from JSON.

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
@@ -2522,6 +2522,13 @@ public class DataflowPipelineRunner extends PipelineRunner<DataflowPipelineJob> 
         return ValueWithRecordId.ValueWithRecordIdCoder.of(source.getDefaultOutputCoder());
       }
 
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        super.populateDisplayData(builder);
+        builder.add(DisplayData.item("source", source.getClass()));
+        builder.include(source);
+      }
+
       public UnboundedSource<T, ?> getSource() {
         return source;
       }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/dataflow/DataflowUnboundedReadFromBoundedSource.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/dataflow/DataflowUnboundedReadFromBoundedSource.java
@@ -103,7 +103,14 @@ public class DataflowUnboundedReadFromBoundedSource<T> extends PTransform<PInput
 
   @Override
   public String getKindString() {
-    return "Read(" + approximateSimpleName(source.getClass()) + ")";
+    String sourceName;
+    if (source.getClass().isAnonymousClass()) {
+      sourceName = "AnonymousSource";
+    } else {
+      sourceName = approximateSimpleName(source.getClass());
+    }
+
+    return "Read(" + sourceName + ")";
   }
 
   @Override
@@ -179,6 +186,13 @@ public class DataflowUnboundedReadFromBoundedSource<T> extends PTransform<PInput
     @Override
     public Coder<Checkpoint<T>> getCheckpointMarkCoder() {
       return new CheckpointCoder<>(boundedSource.getDefaultOutputCoder());
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder.add(DisplayData.item("source", boundedSource.getClass()));
+      builder.include(boundedSource);
     }
 
     @VisibleForTesting

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/Combine.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/Combine.java
@@ -2293,6 +2293,11 @@ public class Combine {
 
               c.output(KV.of(key, combineFnRunner.apply(key, c.element().getValue(), c)));
             }
+
+            @Override
+            public void populateDisplayData(DisplayData.Builder builder) {
+              Combine.GroupedValues.this.populateDisplayData(builder);
+            }
           }).withSideInputs(sideInputs));
 
       try {

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/options/ProxyInvocationHandlerTest.java
@@ -855,6 +855,29 @@ public class ProxyInvocationHandlerTest {
   }
 
   @Test
+  public void testDisplayDataArrayValue() throws Exception {
+    ArrayOptions options = PipelineOptionsFactory.as(ArrayOptions.class);
+    options.setDeepArray(new String[][] {new String[] {"a", "b"}, new String[] {"c"}});
+    options.setDeepPrimitiveArray(new int[][] {new int[] {1, 2}, new int[] {3}});
+
+    DisplayData data = DisplayData.from(options);
+    assertThat(data, hasDisplayItem("deepArray", "[[a, b], [c]]"));
+    assertThat(data, hasDisplayItem("deepPrimitiveArray", "[[1, 2], [3]]"));
+
+    ArrayOptions deserializedOptions = serializeDeserialize(ArrayOptions.class, options);
+    DisplayData deserializedData = DisplayData.from(deserializedOptions);
+    assertThat(deserializedData, hasDisplayItem("deepPrimitiveArray", "[[1, 2], [3]]"));
+  }
+
+  private interface ArrayOptions extends PipelineOptions {
+    String[][] getDeepArray();
+    void setDeepArray(String[][] value);
+
+    int[][] getDeepPrimitiveArray();
+    void setDeepPrimitiveArray(int[][] value);
+  }
+
+  @Test
   public void testDisplayDataJsonSerialization() throws IOException {
     FooOptions options = PipelineOptionsFactory.as(FooOptions.class);
     options.setFoo("bar");

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/dataflow/DataflowUnboundedReadFromBoundedSourceTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/runners/dataflow/DataflowUnboundedReadFromBoundedSourceTest.java
@@ -268,6 +268,53 @@ public class DataflowUnboundedReadFromBoundedSourceTest {
     unboundedSource.createReader(options, checkpoint).getCurrent();
   }
 
+  @Test
+  public void testKind() {
+    DataflowUnboundedReadFromBoundedSource<?> read = new
+        DataflowUnboundedReadFromBoundedSource<>(new NoopNamedSource());
+
+    assertEquals("Read(NoopNamedSource)", read.getKindString());
+  }
+
+  @Test
+  public void testKindAnonymousSource() {
+    NoopNamedSource anonSource = new NoopNamedSource() {};
+    DataflowUnboundedReadFromBoundedSource<?> read = new
+        DataflowUnboundedReadFromBoundedSource<>(anonSource);
+
+    assertEquals("Read(AnonymousSource)", read.getKindString());
+  }
+
+  /** Source implementation only useful for its identity. */
+  static class NoopNamedSource extends BoundedSource<String> {
+    @Override
+    public List<? extends BoundedSource<String>> splitIntoBundles(long desiredBundleSizeBytes,
+        PipelineOptions options) throws Exception {
+      return null;
+    }
+    @Override
+    public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
+      return 0;
+    }
+    @Override
+    public boolean producesSortedKeys(PipelineOptions options) throws Exception {
+      return false;
+    }
+    @Override
+    public BoundedReader<String> createReader(
+        PipelineOptions options) throws IOException {
+      return null;
+    }
+    @Override
+    public void validate() {
+
+    }
+    @Override
+    public Coder<String> getDefaultOutputCoder() {
+      return null;
+    }
+  }
+
   /**
    * Generate byte array of given size.
    */

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayDataEvaluator.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayDataEvaluator.java
@@ -40,10 +40,11 @@ public class DisplayDataEvaluator {
   private final PipelineOptions options;
 
   /**
-   * Create a new {@link DisplayDataEvaluator} using {@link TestPipeline#testingPipelineOptions()}.
+   * Create a new {@link DisplayDataEvaluator} using options returned from
+   * {@link #getDefaultOptions()}.
    */
   public static DisplayDataEvaluator create() {
-    return create(TestPipeline.testingPipelineOptions());
+    return create(getDefaultOptions());
   }
 
   /**
@@ -51,6 +52,13 @@ public class DisplayDataEvaluator {
    */
   public static DisplayDataEvaluator create(PipelineOptions pipelineOptions) {
     return new DisplayDataEvaluator(pipelineOptions);
+  }
+
+  /**
+   * The default {@link PipelineOptions} which will be used by {@link #create()}.
+   */
+  public static PipelineOptions getDefaultOptions() {
+    return TestPipeline.testingPipelineOptions();
   }
 
   private DisplayDataEvaluator(PipelineOptions options) {

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayDataEvaluator.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/transforms/display/DisplayDataEvaluator.java
@@ -97,8 +97,8 @@ public class DisplayDataEvaluator {
 
     Pipeline pipeline = Pipeline.create(options);
     pipeline
-      .apply(input)
-      .apply(root);
+      .apply("Input", input)
+      .apply("Transform", root);
 
     PrimitiveDisplayDataPTransformVisitor visitor = new PrimitiveDisplayDataPTransformVisitor(root);
     pipeline.traverseTopologically(visitor);
@@ -116,7 +116,7 @@ public class DisplayDataEvaluator {
       final PTransform<? super PBegin, ? extends POutput> root) {
     Pipeline pipeline = Pipeline.create(options);
     pipeline
-        .apply(root);
+        .apply("SourceTransform", root);
 
     return displayDataForPipeline(pipeline, root);
   }


### PR DESCRIPTION
Backport display data changes from:

- [#607 Mark primitive display data tests RunnableOnService](https://github.com/apache/incubator-beam/pull/607)
- [#1029 Correctly implement display data for DataflowRunner Read transforms](https://github.com/apache/incubator-beam/pull/1029)
- [#1034 PipelineOptions display data needs to handle array types](https://github.com/apache/incubator-beam/pull/1034)