### PR TITLE
Backport Apache Beam PR #1109

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/AvroSource.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/AvroSource.java
@@ -27,6 +27,7 @@ import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
 import com.google.cloud.dataflow.sdk.util.AvroUtils;
 import com.google.cloud.dataflow.sdk.util.AvroUtils.AvroMetadata;
 import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
@@ -47,6 +48,8 @@ import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectStreamException;
 import java.io.PushbackInputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -54,6 +57,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
@@ -165,7 +170,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
    * to read records of the given type from a file pattern.
    */
   public static <T> Read.Bounded<T> readFromFileWithClass(String filePattern, Class<T> clazz) {
-    return Read.from(new AvroSource<T>(filePattern, DEFAULT_MIN_BUNDLE_SIZE,
+    return Read.from(new AvroSource<>(filePattern, DEFAULT_MIN_BUNDLE_SIZE,
         ReflectData.get().getSchema(clazz).toString(), clazz, null, null));
   }
 
@@ -219,14 +224,14 @@ public class AvroSource<T> extends BlockBasedSource<T> {
    * <p>Does not modify this object.
    */
   public AvroSource<T> withMinBundleSize(long minBundleSize) {
-    return new AvroSource<T>(
+    return new AvroSource<>(
         getFileOrPatternSpec(), minBundleSize, readSchemaString, type, codec, syncMarker);
   }
 
   private AvroSource(String fileNameOrPattern, long minBundleSize, String schema, Class<T> type,
       String codec, byte[] syncMarker) {
     super(fileNameOrPattern, minBundleSize);
-    this.readSchemaString = schema;
+    this.readSchemaString = internSchemaString(schema);
     this.codec = codec;
     this.syncMarker = syncMarker;
     this.type = type;
@@ -236,11 +241,11 @@ public class AvroSource<T> extends BlockBasedSource<T> {
   private AvroSource(String fileName, long minBundleSize, long startOffset, long endOffset,
       String schema, Class<T> type, String codec, byte[] syncMarker, String fileSchema) {
     super(fileName, minBundleSize, startOffset, endOffset);
-    this.readSchemaString = schema;
+    this.readSchemaString = internSchemaString(schema);
     this.codec = codec;
     this.syncMarker = syncMarker;
     this.type = type;
-    this.fileSchemaString = fileSchema;
+    this.fileSchemaString = internSchemaString(fileSchema);
   }
 
   @Override
@@ -278,13 +283,18 @@ public class AvroSource<T> extends BlockBasedSource<T> {
         readSchemaString = metadata.getSchemaString();
       }
     }
-    return new AvroSource<T>(fileName, getMinBundleSize(), start, end, readSchemaString, type,
+    // Note that if the fileSchemaString is equivalent to the readSchemaString, "intern"ing
+    // the string will occur within the constructor and return the same reference as the
+    // readSchemaString. This allows for Java to have an efficient serialization since it
+    // will only encode the schema once while just storing pointers to the encoded version
+    // within this source.
+    return new AvroSource<>(fileName, getMinBundleSize(), start, end, readSchemaString, type,
         codec, syncMarker, fileSchemaString);
   }
 
   @Override
   protected BlockBasedReader<T> createSingleFileReader(PipelineOptions options) {
-    return new AvroReader<T>(this);
+    return new AvroReader<>(this);
   }
 
   @Override
@@ -295,8 +305,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
   @Override
   public AvroCoder<T> getDefaultOutputCoder() {
     if (coder == null) {
-      Schema.Parser parser = new Schema.Parser();
-      coder = AvroCoder.of(type, parser.parse(readSchemaString));
+      coder = AvroCoder.of(type, internOrParseSchemaString(readSchemaString));
     }
     return coder;
   }
@@ -305,28 +314,28 @@ public class AvroSource<T> extends BlockBasedSource<T> {
     return readSchemaString;
   }
 
-  private Schema getReadSchema() {
+  @VisibleForTesting
+  Schema getReadSchema() {
     if (readSchemaString == null) {
       return null;
     }
 
     // If the schema has not been parsed, parse it.
     if (readSchema == null) {
-      Schema.Parser parser = new Schema.Parser();
-      readSchema = parser.parse(readSchemaString);
+      readSchema = internOrParseSchemaString(readSchemaString);
     }
     return readSchema;
   }
 
-  private Schema getFileSchema() {
+  @VisibleForTesting
+  Schema getFileSchema() {
     if (fileSchemaString == null) {
       return null;
     }
 
     // If the schema has not been parsed, parse it.
     if (fileSchema == null) {
-      Schema.Parser parser = new Schema.Parser();
-      fileSchema = parser.parse(fileSchemaString);
+      fileSchema = internOrParseSchemaString(fileSchemaString);
     }
     return fileSchema;
   }
@@ -348,6 +357,64 @@ public class AvroSource<T> extends BlockBasedSource<T> {
       return new GenericDatumReader<>(fileSchema, readSchema);
     } else {
       return new ReflectDatumReader<>(fileSchema, readSchema);
+    }
+  }
+
+  // A logical reference cache used to store schemas and schema strings to allow us to
+  // "intern" values and reduce the number of copies of equivalent objects.
+  private static final Map<String, Schema> schemaLogicalReferenceCache = new WeakHashMap<>();
+  private static final Map<String, String> schemaStringLogicalReferenceCache = new WeakHashMap<>();
+
+  // We avoid String.intern() because depending on the JVM, these may be added to the PermGenSpace
+  // which we want to avoid otherwise we could run out of PermGenSpace.
+  private static synchronized String internSchemaString(String schema) {
+    String internSchema = schemaStringLogicalReferenceCache.get(schema);
+    if (internSchema != null) {
+      return internSchema;
+    }
+    schemaStringLogicalReferenceCache.put(schema, schema);
+    return schema;
+  }
+
+  private static synchronized Schema internOrParseSchemaString(String schemaString) {
+    Schema schema = schemaLogicalReferenceCache.get(schemaString);
+    if (schema != null) {
+      return schema;
+    }
+    Schema.Parser parser = new Schema.Parser();
+    schema = parser.parse(schemaString);
+    schemaLogicalReferenceCache.put(schemaString, schema);
+    return schema;
+  }
+
+  // Reading the object from Java serialization typically does not go through the constructor,
+  // we use readResolve to replace the constructed instance with one which uses the constructor
+  // allowing us to intern any schemas.
+  @SuppressWarnings("unused")
+  private Object readResolve() throws ObjectStreamException {
+    switch (getMode()) {
+      case SINGLE_FILE_OR_SUBRANGE:
+        return new AvroSource<>(
+            getFileOrPatternSpec(),
+            getMinBundleSize(),
+            getStartOffset(),
+            getEndOffset(),
+            readSchemaString,
+            type,
+            codec,
+            syncMarker,
+            fileSchemaString);
+      case FILEPATTERN:
+        return new AvroSource<>(
+            getFileOrPatternSpec(),
+            getMinBundleSize(),
+            readSchemaString,
+            type,
+            codec,
+            syncMarker);
+        default:
+          throw new InvalidObjectException(
+              String.format("Unknown mode %s for AvroSource %s", getMode(), this));
     }
   }
 

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/AvroSourceTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/AvroSourceTest.java
@@ -21,6 +21,8 @@ import static com.google.cloud.dataflow.sdk.transforms.display.DisplayDataMatche
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -34,6 +36,8 @@ import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.testing.SourceTestUtils;
 import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
+import com.google.cloud.dataflow.sdk.util.AvroUtils;
+import com.google.cloud.dataflow.sdk.util.SerializableUtils;
 import com.google.common.base.MoreObjects;
 
 import org.apache.avro.Schema;
@@ -425,6 +429,45 @@ public class AvroSourceTest {
     }
 
     assertThat(actual, containsInAnyOrder(expected.toArray()));
+  }
+
+  @Test
+  public void testSchemaStringIsInterned() throws Exception {
+    List<Bird> birds = createRandomRecords(100);
+    String filename = generateTestFile("tmp.avro", birds, SyncBehavior.SYNC_DEFAULT, 0,
+        AvroCoder.of(Bird.class), DataFileConstants.NULL_CODEC);
+    String schemaA = AvroUtils.readMetadataFromFile(filename).getSchemaString();
+    String schemaB = AvroUtils.readMetadataFromFile(filename).getSchemaString();
+    assertNotSame(schemaA, schemaB);
+
+    AvroSource<GenericRecord> sourceA = AvroSource.from(filename).withSchema(schemaA);
+    AvroSource<GenericRecord> sourceB = AvroSource.from(filename).withSchema(schemaB);
+    assertSame(sourceA.getSchema(), sourceB.getSchema());
+
+    // Ensure that deserialization still goes through interning
+    AvroSource<GenericRecord> sourceC = SerializableUtils.clone(sourceB);
+    assertSame(sourceA.getSchema(), sourceC.getSchema());
+  }
+
+  @Test
+  public void testSchemaIsInterned() throws Exception {
+    List<Bird> birds = createRandomRecords(100);
+    String filename = generateTestFile("tmp.avro", birds, SyncBehavior.SYNC_DEFAULT, 0,
+        AvroCoder.of(Bird.class), DataFileConstants.NULL_CODEC);
+    String schemaA = AvroUtils.readMetadataFromFile(filename).getSchemaString();
+    String schemaB = AvroUtils.readMetadataFromFile(filename).getSchemaString();
+    assertNotSame(schemaA, schemaB);
+
+    AvroSource<GenericRecord> sourceA = (AvroSource<GenericRecord>) AvroSource.from(filename)
+        .withSchema(schemaA).createForSubrangeOfFile(filename, 0L, 0L);
+    AvroSource<GenericRecord> sourceB = (AvroSource<GenericRecord>) AvroSource.from(filename)
+        .withSchema(schemaB).createForSubrangeOfFile(filename, 0L, 0L);
+    assertSame(sourceA.getReadSchema(), sourceA.getFileSchema());
+    assertSame(sourceA.getReadSchema(), sourceB.getReadSchema());
+    assertSame(sourceA.getReadSchema(), sourceB.getFileSchema());
+
+    // Schemas are transient and not serialized thus we don't need to worry about interning
+    // after deserialization.
   }
 
   private void assertEqualsWithGeneric(List<Bird> expected, List<GenericRecord> actual) {


### PR DESCRIPTION
https://github.com/apache/incubator-beam/pull/1109

Diff (Apache Beam on left, Dataflow on right):
AvroSource.java:
```
2,8c2
<  * Licensed to the Apache Software Foundation (ASF) under one
<  * or more contributor license agreements.  See the NOTICE file
<  * distributed with this work for additional information
<  * regarding copyright ownership.  The ASF licenses this file
<  * to you under the Apache License, Version 2.0 (the
<  * "License"); you may not use this file except in compliance
<  * with the License.  You may obtain a copy of the License at
---
>  * Copyright (C) 2015 Google Inc.
10c4,8
<  *     http://www.apache.org/licenses/LICENSE-2.0
---
>  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
>  * use this file except in compliance with the License. You may obtain a copy of
>  * the License at
>  *
>  * http://www.apache.org/licenses/LICENSE-2.0
13,16c11,14
<  * distributed under the License is distributed on an "AS IS" BASIS,
<  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
<  * See the License for the specific language governing permissions and
<  * limitations under the License.
---
>  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
>  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
>  * License for the specific language governing permissions and limitations under
>  * the License.
18c16,17
< package org.apache.beam.sdk.io;
---
> 
> package com.google.cloud.dataflow.sdk.io;
23a23,29
> import com.google.cloud.dataflow.sdk.annotations.Experimental;
> import com.google.cloud.dataflow.sdk.coders.AvroCoder;
> import com.google.cloud.dataflow.sdk.options.PipelineOptions;
> import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
> import com.google.cloud.dataflow.sdk.util.AvroUtils;
> import com.google.cloud.dataflow.sdk.util.AvroUtils.AvroMetadata;
> import com.google.cloud.dataflow.sdk.values.PCollection;
24a31,46
> 
> import org.apache.avro.Schema;
> import org.apache.avro.file.CodecFactory;
> import org.apache.avro.file.DataFileConstants;
> import org.apache.avro.generic.GenericDatumReader;
> import org.apache.avro.generic.GenericRecord;
> import org.apache.avro.io.BinaryDecoder;
> import org.apache.avro.io.DatumReader;
> import org.apache.avro.io.DecoderFactory;
> import org.apache.avro.reflect.ReflectData;
> import org.apache.avro.reflect.ReflectDatumReader;
> import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
> import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
> import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
> import org.apache.commons.compress.utils.CountingInputStream;
> 
41a64
> 
43,63d65
< import org.apache.avro.Schema;
< import org.apache.avro.file.CodecFactory;
< import org.apache.avro.file.DataFileConstants;
< import org.apache.avro.generic.GenericDatumReader;
< import org.apache.avro.generic.GenericRecord;
< import org.apache.avro.io.BinaryDecoder;
< import org.apache.avro.io.DatumReader;
< import org.apache.avro.io.DecoderFactory;
< import org.apache.avro.reflect.ReflectData;
< import org.apache.avro.reflect.ReflectDatumReader;
< import org.apache.beam.sdk.annotations.Experimental;
< import org.apache.beam.sdk.coders.AvroCoder;
< import org.apache.beam.sdk.options.PipelineOptions;
< import org.apache.beam.sdk.runners.PipelineRunner;
< import org.apache.beam.sdk.util.AvroUtils;
< import org.apache.beam.sdk.util.AvroUtils.AvroMetadata;
< import org.apache.beam.sdk.values.PCollection;
< import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
< import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
< import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
< import org.apache.commons.compress.utils.CountingInputStream;
123d124
<  *
461c462
<           return new SnappyCompressorInputStream(byteStream, 1 << 16 /* Avro uses 64KB blocks */);
---
>           return new SnappyCompressorInputStream(byteStream, 1 << 16 /* Avro uses 64KB blocks. */);
```

AvroSourceTest.java:
```
2,8c2
<  * Licensed to the Apache Software Foundation (ASF) under one
<  * or more contributor license agreements.  See the NOTICE file
<  * distributed with this work for additional information
<  * regarding copyright ownership.  The ASF licenses this file
<  * to you under the Apache License, Version 2.0 (the
<  * "License"); you may not use this file except in compliance
<  * with the License.  You may obtain a copy of the License at
---
>  * Copyright (C) 2015 Google Inc.
10c4,8
<  *     http://www.apache.org/licenses/LICENSE-2.0
---
>  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
>  * use this file except in compliance with the License. You may obtain a copy of
>  * the License at
>  *
>  * http://www.apache.org/licenses/LICENSE-2.0
13,16c11,14
<  * distributed under the License is distributed on an "AS IS" BASIS,
<  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
<  * See the License for the specific language governing permissions and
<  * limitations under the License.
---
>  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
>  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
>  * License for the specific language governing permissions and limitations under
>  * the License.
18d15
< package org.apache.beam.sdk.io;
20c17,20
< import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
---
> package com.google.cloud.dataflow.sdk.io;
> 
> import static com.google.cloud.dataflow.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
> 
28a29,40
> import com.google.cloud.dataflow.sdk.coders.AvroCoder;
> import com.google.cloud.dataflow.sdk.coders.DefaultCoder;
> import com.google.cloud.dataflow.sdk.io.AvroSource.AvroReader;
> import com.google.cloud.dataflow.sdk.io.AvroSource.AvroReader.Seeker;
> import com.google.cloud.dataflow.sdk.io.BlockBasedSource.BlockBasedReader;
> import com.google.cloud.dataflow.sdk.io.BoundedSource.BoundedReader;
> import com.google.cloud.dataflow.sdk.options.PipelineOptions;
> import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
> import com.google.cloud.dataflow.sdk.testing.SourceTestUtils;
> import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
> import com.google.cloud.dataflow.sdk.util.AvroUtils;
> import com.google.cloud.dataflow.sdk.util.SerializableUtils;
30,40c42
< import java.io.ByteArrayInputStream;
< import java.io.File;
< import java.io.FileOutputStream;
< import java.io.IOException;
< import java.io.PushbackInputStream;
< import java.util.ArrayList;
< import java.util.Collections;
< import java.util.List;
< import java.util.NoSuchElementException;
< import java.util.Objects;
< import java.util.Random;
---
> 
50,61d51
< import org.apache.beam.sdk.coders.AvroCoder;
< import org.apache.beam.sdk.coders.DefaultCoder;
< import org.apache.beam.sdk.io.AvroSource.AvroReader;
< import org.apache.beam.sdk.io.AvroSource.AvroReader.Seeker;
< import org.apache.beam.sdk.io.BlockBasedSource.BlockBasedReader;
< import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
< import org.apache.beam.sdk.options.PipelineOptions;
< import org.apache.beam.sdk.options.PipelineOptionsFactory;
< import org.apache.beam.sdk.testing.SourceTestUtils;
< import org.apache.beam.sdk.transforms.display.DisplayData;
< import org.apache.beam.sdk.util.AvroUtils;
< import org.apache.beam.sdk.util.SerializableUtils;
69a60,71
> import java.io.ByteArrayInputStream;
> import java.io.File;
> import java.io.FileOutputStream;
> import java.io.IOException;
> import java.io.PushbackInputStream;
> import java.util.ArrayList;
> import java.util.Collections;
> import java.util.List;
> import java.util.NoSuchElementException;
> import java.util.Objects;
> import java.util.Random;
> 
99a102
>     @SuppressWarnings("deprecation")  // test uses internal AvroCoder code.
145c148
<     // We could make this smaller than 64KB assuming each record is at least B bytes, but then the
---
>     // We could make this smaller than 64K assuming each record is at least B bytes, but then the
200c203
<       assertEquals(Double.valueOf(0.0), reader.getFractionConsumed());
---
>       assertEquals(new Double(0.0), reader.getFractionConsumed());
207c210
<         assertEquals(Double.valueOf(0.0), reader.getFractionConsumed());
---
>         assertEquals(new Double(0.0), reader.getFractionConsumed());
```
