### PR TITLE
Makes UnionCoder public

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/UnionCoder.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/join/UnionCoder.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * A UnionCoder encodes RawUnionValues.
  */
-class UnionCoder extends StandardCoder<RawUnionValue> {
+public class UnionCoder extends StandardCoder<RawUnionValue> {
   // TODO: Think about how to integrate this with a schema object (i.e.
   // a tuple of tuple tags).
   /**


### PR DESCRIPTION
This is useful because users may need to construct a CoGbkResultCoder, and to construct a CoGbkResult Coder you need to construct a UnionCoder. E.g. see http://stackoverflow.com/questions/40367387/how-do-i-setcoders-when-doing-an-end-to-end-test-when-my-coder-requires-a-kvcode

UnionCoder is already public in Apache Beam.

R: @lukecwik 