### PR TITLE
Use a retrying Dataflow Client for DataflowPipelineJob

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/DataflowPipelineRunner.java
@@ -625,7 +625,7 @@ public class DataflowPipelineRunner extends PipelineRunner<DataflowPipelineJob> 
     // regularly and need not be retried automatically.
     DataflowPipelineJob dataflowPipelineJob =
         new DataflowPipelineJob(options.getProject(), jobResult.getId(),
-            Transport.newRawDataflowClient(options).build(), aggregatorTransforms);
+            Transport.newDataflowClient(options).build(), aggregatorTransforms);
 
     // If the service returned client request id, the SDK needs to compare it
     // with the original id generated in the request, if they are not the same

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/Transport.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/Transport.java
@@ -158,17 +158,6 @@ public class Transport {
   }
 
   /**
-   * Returns a Dataflow client that does not automatically retry failed
-   * requests.
-   */
-  public static Dataflow.Builder
-      newRawDataflowClient(DataflowPipelineOptions options) {
-    return newDataflowClient(options)
-        .setHttpRequestInitializer(options.getGcpCredential())
-        .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
-  }
-
-  /**
    * Returns a Cloud Storage client builder.
    *
    * <p>Note: this client's endpoint is <b>not</b> modified by the


### PR DESCRIPTION
Beam already does this; this will make DataflowPipelineJob.cancel() non-flaky.