### PR TITLE
KafkaIO should return one split for each of partition.

### DIFF
--- a/contrib/kafka/src/main/java/com/google/cloud/dataflow/contrib/kafka/KafkaIO.java
+++ b/contrib/kafka/src/main/java/com/google/cloud/dataflow/contrib/kafka/KafkaIO.java
@@ -44,7 +44,6 @@ import com.google.cloud.dataflow.sdk.values.PDone;
 import com.google.cloud.dataflow.sdk.values.PInput;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
@@ -714,24 +713,12 @@ public class KafkaIO {
       this.consumerConfig = consumerConfig;
     }
 
-    /**
-     * The partitions are evenly distributed among the splits. The number of splits returned is
-     * {@code min(desiredNumSplits, totalNumPartitions)}, though better not to depend on the exact
-     * count.
-     *
-     * <p> It is important to assign the partitions deterministically so that we can support
-     * resuming a split from last checkpoint. The Kafka partitions are sorted by {@code <topic,
-     * partition>} and then assigned to splits in round-robin order.
-     */
-    @Override
-    public List<UnboundedKafkaSource<K, V>> generateInitialSplits(
-        int desiredNumSplits, PipelineOptions options) throws Exception {
+    private List<TopicPartition> fetchKafkaPartitions() {
 
       List<TopicPartition> partitions = new ArrayList<>(assignedPartitions);
 
       // (a) fetch partitions for each topic
       // (b) sort by <topic, partition>
-      // (c) round-robin assign the partitions to splits
 
       if (partitions.isEmpty()) {
         try (Consumer<?, ?> consumer = consumerFactoryFn.apply(consumerConfig)) {
@@ -758,33 +745,35 @@ public class KafkaIO {
           partitions.size() > 0,
           "Could not find any partitions. Please check Kafka configuration and topic names");
 
-      // one split per partition, except when desiredNumSplits is -1, which is a special case
-      // for DirectDataflowRunner that requires single split.
-      int numSplits = desiredNumSplits == -1 ? 1 : partitions.size();
-      List<List<TopicPartition>> assignments = new ArrayList<>(numSplits);
+      return partitions;
+    }
 
-      for (int i = 0; i < numSplits; i++) {
-        assignments.add(new ArrayList<TopicPartition>());
-      }
+    /**
+     * Returns one split for each of the Kafka partitions.
+     *
+     * <p> It is important to sort the partitions deterministically so that we can support
+     * resuming a split from last checkpoint. The Kafka partitions are sorted by {@code <topic,
+     * partition>}.
+     */
+    @Override
+    public List<UnboundedKafkaSource<K, V>> generateInitialSplits(
+        int desiredNumSplits, PipelineOptions options) throws Exception {
+
+      List<TopicPartition> partitions = fetchKafkaPartitions();
+
+      List<UnboundedKafkaSource<K, V>> result = new ArrayList<>(partitions.size());
+
+      // one split for each partition.
       for (int i = 0; i < partitions.size(); i++) {
-        assignments.get(i % numSplits).add(partitions.get(i));
-      }
+        TopicPartition partition = partitions.get(i);
 
-      List<UnboundedKafkaSource<K, V>> result = new ArrayList<>(numSplits);
-
-      for (int i = 0; i < numSplits; i++) {
-        List<TopicPartition> assignedToSplit = assignments.get(i);
-
-        LOG.info(
-            "Partitions assigned to split {} : {}",
-            i,
-            Joiner.on(",").join(assignedToSplit));
+        LOG.info("Partition assigned to split {} : {}", i, partition);
 
         result.add(
-            new UnboundedKafkaSource<K, V>(
+            new UnboundedKafkaSource<>(
                 i,
                 this.topics,
-                assignedToSplit,
+                ImmutableList.of(partition),
                 this.keyCoder,
                 this.valueCoder,
                 this.timestampFn,
@@ -804,7 +793,17 @@ public class KafkaIO {
         LOG.warn("Looks like generateSplits() is not called. Generate single split.");
         try {
           return new UnboundedKafkaReader<K, V>(
-              generateInitialSplits(-1, options).get(0), checkpointMark);
+              new UnboundedKafkaSource<>(
+                0,
+                this.topics,
+                fetchKafkaPartitions(),
+                this.keyCoder,
+                this.valueCoder,
+                this.timestampFn,
+                this.watermarkFn,
+                this.consumerFactoryFn,
+                this.consumerConfig),
+              checkpointMark);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }

--- a/contrib/kafka/src/main/java/com/google/cloud/dataflow/contrib/kafka/KafkaIO.java
+++ b/contrib/kafka/src/main/java/com/google/cloud/dataflow/contrib/kafka/KafkaIO.java
@@ -794,15 +794,15 @@ public class KafkaIO {
         try {
           return new UnboundedKafkaReader<K, V>(
               new UnboundedKafkaSource<>(
-                0,
-                this.topics,
-                fetchKafkaPartitions(),
-                this.keyCoder,
-                this.valueCoder,
-                this.timestampFn,
-                this.watermarkFn,
-                this.consumerFactoryFn,
-                this.consumerConfig),
+                  0,
+                  this.topics,
+                  fetchKafkaPartitions(),
+                  this.keyCoder,
+                  this.valueCoder,
+                  this.timestampFn,
+                  this.watermarkFn,
+                  this.consumerFactoryFn,
+                  this.consumerConfig),
               checkpointMark);
         } catch (Exception e) {
           throw new RuntimeException(e);

--- a/contrib/kafka/src/test/java/com/google/cloud/dataflow/contrib/kafka/KafkaIOTest.java
+++ b/contrib/kafka/src/test/java/com/google/cloud/dataflow/contrib/kafka/KafkaIOTest.java
@@ -26,7 +26,6 @@ import com.google.cloud.dataflow.sdk.coders.BigEndianLongCoder;
 import com.google.cloud.dataflow.sdk.io.Read;
 import com.google.cloud.dataflow.sdk.io.UnboundedSource;
 import com.google.cloud.dataflow.sdk.io.UnboundedSource.UnboundedReader;
-import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Count;

--- a/contrib/kafka/src/test/java/com/google/cloud/dataflow/contrib/kafka/KafkaIOTest.java
+++ b/contrib/kafka/src/test/java/com/google/cloud/dataflow/contrib/kafka/KafkaIOTest.java
@@ -365,9 +365,7 @@ public class KafkaIOTest {
             com.google.cloud.dataflow.contrib.kafka.KafkaCheckpointMark>
         source =
             mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
-                .makeSource()
-                .generateInitialSplits(-1, PipelineOptionsFactory.fromArgs(new String[0]).create())
-                .get(0);
+                .makeSource();
 
     UnboundedReader<com.google.cloud.dataflow.contrib.kafka.KafkaRecord<Integer, Long>> reader =
         source.createReader(null, null);


### PR DESCRIPTION
KafkaIO should return one split for each of partition.

This is the actual unit of parallelism for Kafka topic. desiredNumSplits that Dataflow passes to a custom source is very low when maxNumWorkers is set. It asks for
just one split for each of the workers. This limits use of CPU cores on the workers essentially making autoscaling use more resources without improving performance.

This includes a hack to force single split in many unit tests since DirectPipelineRunner and InProcessPipelineRunner don't seem to read from more than one split.