### PR TITLE
Templated jobs should use custom IO for BigQuery

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/TemplatingDataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/TemplatingDataflowPipelineRunner.java
@@ -69,8 +69,8 @@ public class TemplatingDataflowPipelineRunner extends PipelineRunner<DataflowPip
   public static TemplatingDataflowPipelineRunner fromOptions(PipelineOptions options) {
     DataflowPipelineDebugOptions dataflowOptions =
         PipelineOptionsValidator.validate(DataflowPipelineDebugOptions.class, options);
-    List<String> experiments = null;
-    if (dataflowOptions.getExperiments() == null) {
+    List<String> experiments = dataflowOptions.getExperiments();
+    if (experiments == null) {
       experiments = new ArrayList<>();
       dataflowOptions.setExperiments(experiments);
     }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/TemplatingDataflowPipelineRunner.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/TemplatingDataflowPipelineRunner.java
@@ -31,6 +31,8 @@ import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -67,6 +69,13 @@ public class TemplatingDataflowPipelineRunner extends PipelineRunner<DataflowPip
   public static TemplatingDataflowPipelineRunner fromOptions(PipelineOptions options) {
     DataflowPipelineDebugOptions dataflowOptions =
         PipelineOptionsValidator.validate(DataflowPipelineDebugOptions.class, options);
+    List<String> experiments = null;
+    if (dataflowOptions.getExperiments() == null) {
+      experiments = new ArrayList<>();
+      dataflowOptions.setExperiments(experiments);
+    }
+    experiments.add("enable_custom_bigquery_source");
+    experiments.add("enable_custom_bigquery_sink");
     DataflowPipelineRunner dataflowPipelineRunner =
         DataflowPipelineRunner.fromOptions(dataflowOptions);
     checkArgument(!Strings.isNullOrEmpty(dataflowOptions.getDataflowJobFile()),


### PR DESCRIPTION
R: @dhalperi 

Using custom IO for this anticipates working with Beam, and supports better iteration by not requiring service cooperation for template execution.  The data cleanup regressions are suboptimal, but acceptable.