### PR TITLE
Increase KafkaIO version to 0.2.0

### DIFF
--- a/contrib/kafka/README.md
+++ b/contrib/kafka/README.md
@@ -1,0 +1,36 @@
+# KafkaIO : Dataflow Unbounded Source and Sink for Kafka Topics
+
+KafkaIO provides unbounded sources and sinks for [Kafka](https://www.firebase.com/)
+topics. Kafka version 0.9 and above are supported.
+
+## Basic Usage
+ * Read from a topic with 8 byte long keys and string values:
+   ```java
+     PCollection<KV<Long, String>> kafkaRecords =
+       pipeline
+         .applY(KafkaIO.read()
+           .withBootstrapServers("broker_1:9092,broker_2:9092")
+           .withTopics(ImmutableList.of("topic_a"))
+           .withKeyCoder(BigEndianLongCoder.of())
+           .withValueCoder(StringUtf8Coder.of())
+           .withoutMetadata()
+         );
+    ```
+ * Write the same PCollection to a Kafka topic:
+   ```java
+     kafkaRecords.apply(KafkaIO.write()
+       .withBootstrapServers("broker_1:9092,broker_2:9092")
+       .withTopic("results")
+       .withKeyCoder(BigEndianLongCoder.of())
+       .withValueCoder(StringUtf8Coder.of())
+   ```
+
+Please see JavaDoc for KafkaIO in
+[KafkaIO.java](https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/contrib/kafka/src/main/java/com/google/cloud/dataflow/contrib/kafka/KafkaIO.java#L100)
+for complete documentation and a more descriptive usage example.
+
+## Release Notes
+  * **0.2.0** : Assign one split for each of the Kafka topic partitions. This makes Dataflow
+                [Update](https://cloud.google.com/dataflow/pipelines/updating-a-pipeline)
+                from previous version incompatible.
+  * **0.1.0** : KafkaIO with support for Unbounded Source and Sink.

--- a/contrib/kafka/README.md
+++ b/contrib/kafka/README.md
@@ -1,7 +1,7 @@
 # KafkaIO : Dataflow Unbounded Source and Sink for Kafka Topics
 
-KafkaIO provides unbounded sources and sinks for [Kafka](https://www.firebase.com/)
-topics. Kafka version 0.9 and above are supported.
+KafkaIO provides unbounded source and sink for [Kafka](http://kafka.apache.org/)
+topics. Kafka versions 0.9 and above are supported.
 
 ## Basic Usage
 
@@ -9,7 +9,7 @@ topics. Kafka version 0.9 and above are supported.
 ```java
  PCollection<KV<Long, String>> kafkaRecords =
    pipeline
-     .applY(KafkaIO.read()
+     .apply(KafkaIO.read()
        .withBootstrapServers("broker_1:9092,broker_2:9092")
        .withTopics(ImmutableList.of("topic_a"))
        .withKeyCoder(BigEndianLongCoder.of())
@@ -25,6 +25,7 @@ topics. Kafka version 0.9 and above are supported.
    .withTopic("results")
    .withKeyCoder(BigEndianLongCoder.of())
    .withValueCoder(StringUtf8Coder.of())
+ );
 ```
 
 Please see JavaDoc for KafkaIO in

--- a/contrib/kafka/README.md
+++ b/contrib/kafka/README.md
@@ -4,26 +4,28 @@ KafkaIO provides unbounded sources and sinks for [Kafka](https://www.firebase.co
 topics. Kafka version 0.9 and above are supported.
 
 ## Basic Usage
- * Read from a topic with 8 byte long keys and string values:
-   ```java
-     PCollection<KV<Long, String>> kafkaRecords =
-       pipeline
-         .applY(KafkaIO.read()
-           .withBootstrapServers("broker_1:9092,broker_2:9092")
-           .withTopics(ImmutableList.of("topic_a"))
-           .withKeyCoder(BigEndianLongCoder.of())
-           .withValueCoder(StringUtf8Coder.of())
-           .withoutMetadata()
-         );
-    ```
- * Write the same PCollection to a Kafka topic:
-   ```java
-     kafkaRecords.apply(KafkaIO.write()
+
+* Read from a topic with 8 byte long keys and string values:
+```java
+ PCollection<KV<Long, String>> kafkaRecords =
+   pipeline
+     .applY(KafkaIO.read()
        .withBootstrapServers("broker_1:9092,broker_2:9092")
-       .withTopic("results")
+       .withTopics(ImmutableList.of("topic_a"))
        .withKeyCoder(BigEndianLongCoder.of())
        .withValueCoder(StringUtf8Coder.of())
-   ```
+       .withoutMetadata()
+     );
+```
+
+* Write the same PCollection to a Kafka topic:
+```java
+ kafkaRecords.apply(KafkaIO.write()
+   .withBootstrapServers("broker_1:9092,broker_2:9092")
+   .withTopic("results")
+   .withKeyCoder(BigEndianLongCoder.of())
+   .withValueCoder(StringUtf8Coder.of())
+```
 
 Please see JavaDoc for KafkaIO in
 [KafkaIO.java](https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/contrib/kafka/src/main/java/com/google/cloud/dataflow/contrib/kafka/KafkaIO.java#L100)

--- a/contrib/kafka/pom.xml
+++ b/contrib/kafka/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>google-cloud-dataflow-java-contrib-kafka</artifactId>
     <name>Google Cloud Dataflow Kafka IO Library</name>
     <description>Library to read Kafka topics.</description>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 
     <properties>
       <dataflow.version>[1.6.0, 2.0.0)</dataflow.version>


### PR DESCRIPTION
Recent PR #491 changes how KafkaIO splits. This makes it incompatible
with Dataflow update across these two versions.