### PR TITLE
Backport: [BEAM-1160] Fail to split in FileBasedSource if filePattern expands to empty

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/FileBasedSource.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/FileBasedSource.java
@@ -316,7 +316,11 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       try {
         checkState(fileOrPatternSpec.isAccessible(),
             "Bundle splitting should only happen at execution time.");
-        for (final String file : FileBasedSource.expandFilePattern(fileOrPatternSpec.get())) {
+        Collection<String> expandedFiles =
+            FileBasedSource.expandFilePattern(fileOrPatternSpec.get());
+        checkArgument(!expandedFiles.isEmpty(),
+            "Unable to find any files matching %s", fileOrPatternSpec.get());
+        for (final String file : expandedFiles) {
           futures.add(createFutureForFileSplit(file, desiredBundleSizeBytes, options, service));
         }
         List<? extends FileBasedSource<T>> splitResults =

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/FileBasedSourceTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/FileBasedSourceTest.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -70,6 +71,7 @@ public class FileBasedSourceTest {
   Random random = new Random(0L);
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   /**
    * If {@code splitHeader} is null, this is just a simple line-based reader. Otherwise, the file is
@@ -412,6 +414,16 @@ public class FileBasedSourceTest {
         new TestFileBasedSource(file0.getParent() + "/" + "file*", Long.MAX_VALUE, null);
     List<? extends BoundedSource<String>> splits = source.splitIntoBundles(Long.MAX_VALUE, null);
     assertEquals(numFiles, splits.size());
+  }
+
+  @Test
+  public void testSplittingFailsOnEmptyFileExpansion() throws Exception {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    String missingFilePath = tempFolder.newFolder().getAbsolutePath() + "/missing.txt";
+    TestFileBasedSource source = new TestFileBasedSource(missingFilePath, Long.MAX_VALUE, null);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(String.format("Unable to find any files matching %s", missingFilePath));
+    source.splitIntoBundles(1234, options);
   }
 
   @Test


### PR DESCRIPTION
Typically, input file patterns are validated during Pipeline
construction, but standard Read transforms include an option to disable
validation. This is generally useful but can lead to cases where a
Pipeline executes successfully with empty inputs.

This changes the behavior to fail execution on empty file-based inputs
even when validation is disabled.