### PR TITLE
maven-enforcer: require Java 1.8.0 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,34 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>1.4.1</version>
+          <executions>
+            <execution>
+              <id>enforce-java</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <!--
+                    Require Java 8 and above to build the distribution. Note
+                    that this is a requirement on process to build the
+                    distribution only. It is expected for the build to fail
+                    using Java 7, but the output is still required to work on
+                    Java 7.
+                  -->
+                  <requireJavaVersion>
+                    <version>[1.8.0,)</version>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
@@ -264,6 +292,11 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Confirmed manually:

```
➜  DataflowJavaSDK git:(java8-require) ✗ JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_79.jdk/Contents/Home/ mvn clean install
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Google Cloud Dataflow SDK for Java - Parent
[INFO] Google Cloud Dataflow SDK for Java - All
[INFO] Google Cloud Dataflow Java Examples - All
[INFO] Google Cloud Dataflow SDK for Java - Starter Archetype
[INFO] Google Cloud Dataflow SDK for Java - Examples Archetype
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Google Cloud Dataflow SDK for Java - Parent 2.0.0-beta1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.0.0:clean (default-clean) @ google-cloud-dataflow-java-sdk-parent ---
[INFO] Deleting /Users/dhalperi/IdeaProjects/DataflowJavaSDK/target
[INFO] 
[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-java) @ google-cloud-dataflow-java-sdk-parent ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.7.0-79 is not in the allowed range 1.8.0.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Google Cloud Dataflow SDK for Java - Parent ........ FAILURE [  1.065 s]
[INFO] Google Cloud Dataflow SDK for Java - All ........... SKIPPED
[INFO] Google Cloud Dataflow Java Examples - All .......... SKIPPED
[INFO] Google Cloud Dataflow SDK for Java - Starter Archetype SKIPPED
[INFO] Google Cloud Dataflow SDK for Java - Examples Archetype SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.310 s
[INFO] Finished at: 2017-01-05T21:30:30-08:00
[INFO] Final Memory: 11M/310M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce (enforce-java) on project google-cloud-dataflow-java-sdk-parent: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```