### PR TITLE
[BEAM-359] Treat erased type variables as non-deterministic in AvroCoder

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/coders/AvroCoder.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/coders/AvroCoder.java
@@ -474,6 +474,10 @@ public class AvroCoder<T> extends StandardCoder<T> {
           checkMap(context, type, schema);
           break;
         case RECORD:
+          if (!(type.getType() instanceof Class)) {
+            reportError(context, "Cannot determine type from generic %s due to erasure", type);
+            return;
+          }
           checkRecord(type, schema);
           break;
         case UNION:
@@ -694,7 +698,8 @@ public class AvroCoder<T> extends StandardCoder<T> {
      * Extract a field from a class. We need to look at the declared fields so that we can
      * see private fields. We may need to walk up to the parent to get classes from the parent.
      */
-    private static Field getField(Class<?> clazz, String name) {
+    private static Field getField(Class<?> originalClazz, String name) {
+      Class<?> clazz = originalClazz;
       while (clazz != null) {
         for (Field field : clazz.getDeclaredFields()) {
           AvroName avroName = field.getAnnotation(AvroName.class);
@@ -708,7 +713,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
       }
 
       throw new IllegalArgumentException(
-          "Unable to get field " + name + " from class " + clazz);
+          "Unable to get field " + name + " from class " + originalClazz);
     }
   }
 }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/coders/AvroCoderTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/coders/AvroCoderTest.java
@@ -751,4 +751,30 @@ public class AvroCoderTest {
       return Objects.hash(getClass(), onlySomeTypesAllowed);
     }
   }
+
+  @Test
+  public void testAvroCoderForGenerics() throws Exception {
+    Schema fooSchema = AvroCoder.of(Foo.class).getSchema();
+    Schema schema = new Schema.Parser().parse("{"
+            + "\"type\":\"record\","
+            + "\"name\":\"SomeGeneric\","
+            + "\"namespace\":\"ns\","
+            + "\"fields\":["
+            + "  {\"name\":\"foo\", \"type\":" + fooSchema.toString() + "}"
+            + "]}");
+    @SuppressWarnings("rawtypes")
+    AvroCoder<SomeGeneric> coder = AvroCoder.of(SomeGeneric.class, schema);
+
+    assertNonDeterministic(coder,
+            reasonField(SomeGeneric.class, "foo", "erasure"));
+  }
+
+  private static class SomeGeneric<T> {
+    @SuppressWarnings("unused")
+    private T foo;
+  }
+  private static class Foo {
+    @SuppressWarnings("unused")
+    String id;
+  }
 }


### PR DESCRIPTION
This is a back port of a BEAM-359. It allows to create a coder for generics in a case if the schema for the concrete type parameter is provided. The created coder will be treated as non-deterministic.

For more information look at: 
https://issues.apache.org/jira/browse/BEAM-359
https://github.com/apache/beam/commit/9c8dc4fe920618253b425f0d998f8d63552ec358
http://stackoverflow.com/questions/41381648/serializing-generic-class-with-provided-schema-using-avrocoder