### PR TITLE
Add a way to configure ackDeadlineSeconds

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/PubsubIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/PubsubIO.java
@@ -480,6 +480,13 @@ public class PubsubIO {
     }
 
     /**
+     * Set ackDeadlineSeconds for randomly created subscription when subscription is not specified.
+     */
+    public static Bound<String> ackDeadlineSeconds(int ackDeadlineSeconds) {
+      return new Bound<>(DEFAULT_PUBSUB_CODER).ackDeadlineSeconds(ackDeadlineSeconds);
+    }
+
+    /**
      * Creates and returns a transform reading from Cloud Pub/Sub where record timestamps are
      * expected to be provided as Pub/Sub message attributes. The {@code timestampLabel}
      * parameter specifies the name of the attribute that contains the timestamp.
@@ -589,13 +596,16 @@ public class PubsubIO {
       /** Stop after reading for this much time. */
       @Nullable private final Duration maxReadTime;
 
+      /** Set ackDeadlineSeconds for randomly created subscription */
+      @Nullable private final int ackDeadlineSeconds;
+
       private Bound(Coder<T> coder) {
-        this(null, null, null, null, coder, null, 0, null);
+        this(null, null, null, null, coder, null, 0, null, PubsubReader.ACK_TIMEOUT_SEC);
       }
 
       private Bound(String name, ValueProvider<PubsubSubscription> subscription,
           ValueProvider<PubsubTopic> topic, String timestampLabel, Coder<T> coder,
-          String idLabel, int maxNumRecords, Duration maxReadTime) {
+          String idLabel, int maxNumRecords, Duration maxReadTime, int ackDeadlineSeconds) {
         super(name);
         this.subscription = subscription;
         this.topic = topic;
@@ -604,6 +614,7 @@ public class PubsubIO {
         this.idLabel = idLabel;
         this.maxNumRecords = maxNumRecords;
         this.maxReadTime = maxReadTime;
+        this.ackDeadlineSeconds = ackDeadlineSeconds;
       }
 
       /**
@@ -613,7 +624,7 @@ public class PubsubIO {
        */
       public Bound<T> named(String name) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -643,7 +654,14 @@ public class PubsubIO {
         }
         return new Bound<>(name,
             NestedValueProvider.of(subscription, new SubscriptionTranslator()),
-            topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+      }
+
+      /**
+       * Set ackDeadlineSeconds for randomly created subscription when subscription is not specified.
+       */
+      public Bound<T> ackDeadlineSeconds(int ackDeadlineSeconds) {
+        return new Bound<>(name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -668,7 +686,7 @@ public class PubsubIO {
         }
         return new Bound<>(name, subscription,
             NestedValueProvider.of(topic, new TopicTranslator()),
-            timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -680,7 +698,7 @@ public class PubsubIO {
        */
       public Bound<T> timestampLabel(String timestampLabel) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -692,7 +710,7 @@ public class PubsubIO {
        */
       public Bound<T> idLabel(String idLabel) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -706,7 +724,7 @@ public class PubsubIO {
        */
       public <X> Bound<X> withCoder(Coder<X> coder) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -716,7 +734,7 @@ public class PubsubIO {
        */
       public Bound<T> maxNumRecords(int maxNumRecords) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -726,7 +744,7 @@ public class PubsubIO {
        */
       public Bound<T> maxReadTime(Duration maxReadTime) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       @Override
@@ -822,6 +840,10 @@ public class PubsubIO {
         return maxReadTime;
       }
 
+      public int getAckDeadlineSeconds() {
+        return ackDeadlineSeconds;
+      }
+
       /**
        * Default reader when Pubsub subscription has some form of upper bound.
        *
@@ -858,7 +880,7 @@ public class PubsubIO {
               ProjectPath projectPath = PubsubClient.projectPathFromId(projectId);
               try {
                 subscriptionPath =
-                    pubsubClient.createRandomSubscription(projectPath, topicPath, ACK_TIMEOUT_SEC);
+                    pubsubClient.createRandomSubscription(projectPath, topicPath, ackDeadlineSeconds);
               } catch (Exception e) {
                 throw new RuntimeException("Failed to create subscription: ", e);
               }

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/PubsubIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/PubsubIO.java
@@ -596,7 +596,7 @@ public class PubsubIO {
       /** Stop after reading for this much time. */
       @Nullable private final Duration maxReadTime;
 
-      /** Set ackDeadlineSeconds for randomly created subscription */
+      /** Set ackDeadlineSeconds for randomly created subscription. */
       @Nullable private final int ackDeadlineSeconds;
 
       private Bound(Coder<T> coder) {
@@ -624,7 +624,8 @@ public class PubsubIO {
        */
       public Bound<T> named(String name) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords,
+                maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -658,10 +659,12 @@ public class PubsubIO {
       }
 
       /**
-       * Set ackDeadlineSeconds for randomly created subscription when subscription is not specified.
+       * Set ackDeadlineSeconds for randomly created subscription when
+       * subscription is not specified.
        */
       public Bound<T> ackDeadlineSeconds(int ackDeadlineSeconds) {
-        return new Bound<>(name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+        return new Bound<>(name, subscription, topic, timestampLabel, coder, idLabel,
+                maxNumRecords, maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -698,7 +701,8 @@ public class PubsubIO {
        */
       public Bound<T> timestampLabel(String timestampLabel) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords,
+                maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -710,7 +714,8 @@ public class PubsubIO {
        */
       public Bound<T> idLabel(String idLabel) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords,
+                maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -724,7 +729,8 @@ public class PubsubIO {
        */
       public <X> Bound<X> withCoder(Coder<X> coder) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords,
+                maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -734,7 +740,8 @@ public class PubsubIO {
        */
       public Bound<T> maxNumRecords(int maxNumRecords) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords,
+                maxReadTime, ackDeadlineSeconds);
       }
 
       /**
@@ -744,7 +751,8 @@ public class PubsubIO {
        */
       public Bound<T> maxReadTime(Duration maxReadTime) {
         return new Bound<>(
-            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, ackDeadlineSeconds);
+            name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords,
+                maxReadTime, ackDeadlineSeconds);
       }
 
       @Override
@@ -880,7 +888,8 @@ public class PubsubIO {
               ProjectPath projectPath = PubsubClient.projectPathFromId(projectId);
               try {
                 subscriptionPath =
-                    pubsubClient.createRandomSubscription(projectPath, topicPath, ackDeadlineSeconds);
+                    pubsubClient.createRandomSubscription(projectPath,
+                            topicPath, ackDeadlineSeconds);
               } catch (Exception e) {
                 throw new RuntimeException("Failed to create subscription: ", e);
               }

--- a/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/PubsubIOTest.java
+++ b/sdk/src/test/java/com/google/cloud/dataflow/sdk/io/PubsubIOTest.java
@@ -138,6 +138,15 @@ public class PubsubIOTest {
   }
 
   @Test
+  public void testAckDeadlineSeconds() {
+    assertEquals(60, PubsubIO.Read.named("test").getAckDeadlineSeconds());
+    assertEquals(60, PubsubIO.Read.ackDeadlineSeconds(60).getAckDeadlineSeconds());
+    assertEquals(15, PubsubIO.Read.ackDeadlineSeconds(15).getAckDeadlineSeconds());
+    assertEquals(-1, PubsubIO.Read.ackDeadlineSeconds(-1).getAckDeadlineSeconds());
+    assertEquals(0, PubsubIO.Read.ackDeadlineSeconds(0).getAckDeadlineSeconds());
+  }
+
+  @Test
   public void testNullTopic() {
     String subscription = "projects/project/subscriptions/subscription";
     PubsubIO.Read.Bound<String> read = PubsubIO.Read


### PR DESCRIPTION
fixes: #532 

Does no validation of `ackDeadlineSeconds`, I believe acceptable range is t >= 0, and let the exception to be thrown at the random subscription creation time.