### PR TITLE
Small fix for BigtableIO's WriteOperation.finalize

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/bigtable/BigtableIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/bigtable/BigtableIO.java
@@ -976,9 +976,9 @@ public class BigtableIO {
     public void finalize(Iterable<Long> writerResults, PipelineOptions options) {
       long count = 0;
       for (Long value : writerResults) {
-        value += count;
+        count += value;
       }
-      logger.debug("Wrote {} elements to BigtableIO.Sink {}", sink);
+      logger.debug("Wrote {} elements to BigtableIO.Sink {}", count, sink);
     }
 
     @Override


### PR DESCRIPTION
2 line bugfix for the finalize() method