### PR TITLE
Makes cachedSplitResult transient in BigQuerySourceBase

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/io/BigQueryIO.java
@@ -1211,7 +1211,7 @@ public class BigQueryIO {
     protected final BigQueryServices bqServices;
     protected final ValueProvider<String> executingProject;
 
-    private List<BoundedSource<TableRow>> cachedSplitResult;
+    private transient List<BoundedSource<TableRow>> cachedSplitResult;
 
     private BigQuerySourceBase(
         String jobIdToken,


### PR DESCRIPTION
Backport of https://github.com/apache/beam/pull/2635