### PR TITLE
Adding Kafka IO to Dataflow SDK dependencies

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-kafka</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/SdkDependencies.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/SdkDependencies.java
@@ -19,6 +19,7 @@ import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.direct.DirectRunner;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.kafka.KafkaIO;
 
 /**
  * Mark the dependencies as used at compile time.
@@ -26,6 +27,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 class SdkDependencies {
   private Pipeline p;
   private BigQueryIO bigQueryIO;
+  private KafkaIO kafkaIO;
   private DirectRunner directRunner;
   private DataflowRunner dataflowRunner;
 }


### PR DESCRIPTION
Also removing fail-on-warning for Dependency Plugin, as Kafka dependency is not used anywhere and this makes analyze-dependencies fail.
This is because Maven Dependency Pluging analyzes bytecode and if a dependency is not used but declared, generates a warning.

r: @lukecwik 